### PR TITLE
🔨 chore : 클러스터 docker 버전 이슈에 따른 docker-compose.dev.yml 수정

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,8 +2,6 @@
 
 version: "3.8"
 
-name: "ft_dev"
-
 # SECTION : SERVICES
 services:
   backend_dev:
@@ -51,9 +49,6 @@ services:
       dockerfile: Dockerfile.dev
     init: true
     entrypoint: [ sleep, infinity ]
-    configs:
-      - source: postgresql
-        target: /var/lib/postgresql/data/postgresql.conf
     env_file:
       - ./database/.env
     expose:
@@ -64,6 +59,7 @@ services:
     volumes:
       - ./:/workspaces/:cached
       - /var/run/docker.sock:/var/run/docker-host.sock
+      - ./database/postgresql.conf:/var/lib/postgresql/data/postgresql.conf
 
 # SECTION : NETWORKS
 networks:
@@ -72,11 +68,6 @@ networks:
       config:
         - subnet: 172.18.0.0/24
           gateway: 172.18.0.1
-
-# SECTION : CONFIGS
-configs:
-  postgresql:
-    file: ./database/postgresql.conf
 
 # SECTION : VOLUMES
 # volumes:


### PR DESCRIPTION
## 내용
- Issue #16  내용대로 클러스터 Docker Version 이슈 때문에 하위 버전에서도 돌아가게 하기 위해서 `docker-compose.dev.yml` 수정했습니다.
- `name` 디렉티브는 지웠습니다.
- database 개발 환경의 `configs` 디렉티브는 bind mount 로 대체했습니다.

close #16 