### PR TITLE
🔨 chore : channels 테이블에서 is_dm 을 dm_peer_id 로 변경 #37

### DIFF
--- a/database/sql/init_db.sql
+++ b/database/sql/init_db.sql
@@ -54,8 +54,8 @@ CREATE TABLE IF NOT EXISTS match_history (
 CREATE TABLE IF NOT EXISTS channels (
 	channel_id SERIAL PRIMARY KEY,
 	owner_id int REFERENCES users(user_id),
+	dm_peer_id int REFERENCES users(user_id),
 	channel_name varchar(128) NOT NULL,
-	is_dm boolean NOT NULL,
 	member_cnt int NOT NULL,
 	access_mode channel_access_mode NOT NULL,
 	passwd bytea,


### PR DESCRIPTION
## 개요
- #37 사항 반영

## 작업 사항
- `init_db.sql` 에서 `is_dm boolean` 을 `dm_peer_id integer FK` 로 수정

[노션 페이지](https://teal-grill-819.notion.site/DB-0390ec95162a4509aeb18cedbce3e7f2)에 업데이트 완료

close #37 


