### PR TITLE
:recycle: refactor : import 순서 변경 및 TypeORM 링크 규칙 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# MacOS
+.DS_Store

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
+
 import { AppService } from './app.service';
 
 @Controller()

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,10 +1,11 @@
+import { ConfigModule } from '@nestjs/config';
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { ApiConfigModule } from './config/api-config.module';
+import { ApiConfigService } from './config/api-config.service';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { ConfigModule } from '@nestjs/config';
-import { ApiConfigModule } from './config/ApiConfig.module';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { ApiConfigService } from './config/ApiConfig.service';
 
 @Module({
   imports: [

--- a/backend/src/config/api-config.module.ts
+++ b/backend/src/config/api-config.module.ts
@@ -1,6 +1,7 @@
-import { Module } from '@nestjs/common';
-import { ApiConfigService } from './ApiConfig.service';
 import { ConfigService } from '@nestjs/config';
+import { Module } from '@nestjs/common';
+
+import { ApiConfigService } from './api-config.service';
 
 @Module({
   providers: [ApiConfigService, ConfigService],

--- a/backend/src/config/api-config.service.spec.ts
+++ b/backend/src/config/api-config.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+
 import { ApiConfigService } from './api-config.service';
 
 class mockApiConfigService {

--- a/backend/src/config/api-config.service.spec.ts
+++ b/backend/src/config/api-config.service.spec.ts
@@ -1,6 +1,6 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { ApiConfigService } from './ApiConfig.service';
 import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ApiConfigService } from './api-config.service';
 
 class mockApiConfigService {
   get(arg: string) {

--- a/backend/src/config/api-config.service.ts
+++ b/backend/src/config/api-config.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { Injectable } from '@nestjs/common';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 
 @Injectable()
@@ -14,7 +14,7 @@ export class ApiConfigService {
       username: this.configService.get('DB_USER'),
       password: this.configService.get('DB_PASSWORD'),
       database: this.configService.get('DB_NAME'),
-      entities: [__dirname + '/../../**/*.entity{.ts,.js}'],
+      autoLoadEntities: true,
       synchronize: true,
     };
   }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+
 import { AppModule } from './app.module';
 
 async function bootstrap() {


### PR DESCRIPTION
## 개요
- import 규칙 수정

## 작업 사항
- import 규칙에 맞게 순서 수정
- TypeORM entity 링크 규칙 수정

## 변경점
- 모듈 import 규칙 수정
  - 패키지가 우선하고, 개행 하나 이후 작성한 모듈을 작성 이후 알파벳 순으로 정렬

