### PR TITLE
:sparkles: feat : UserGateway userInfo 이벤트 emitter 구현 (gameId 제외) 

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,8 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0",
         "socket.io": "^4.5.4",
-        "typeorm": "^0.3.11"
+        "typeorm": "^0.3.11",
+        "wait-for-expect": "^3.0.2"
       },
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
@@ -8794,6 +8795,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/wait-for-expect": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag=="
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -15609,6 +15615,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "wait-for-expect": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag=="
     },
     "walker": {
       "version": "1.0.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,7 +34,8 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
     "socket.io": "^4.5.4",
-    "typeorm": "^0.3.11"
+    "typeorm": "^0.3.11",
+    "wait-for-expect": "^3.0.2"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { ApiConfigModule } from './config/api-config.module';
 import { ApiConfigService } from './config/api-config.service';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { UserModule } from './user/user.module';
 import { UserStatusModule } from './user-status/user-status.module';
 
 @Module({
@@ -19,6 +20,7 @@ import { UserStatusModule } from './user-status/user-status.module';
         apiConfigService.postgresConfig,
       inject: [ApiConfigService],
     }),
+    UserModule,
     UserStatusModule,
   ],
   controllers: [AppController],

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -62,6 +62,7 @@ export class ActivityGateway
   handleDisconnect(clientSocket: Socket) {
     const socketId = clientSocket.id;
     const userId = this.userSocketStorage.sockets.get(socketId);
+    this.activityManager.deleteActivity(userId);
     this.userSocketStorage.clients.delete(userId);
     this.userSocketStorage.sockets.delete(socketId);
     this.userRelationshipStorage.unload(userId);
@@ -90,6 +91,6 @@ export class ActivityGateway
     //   this.chatsGateway.joinRoom(clientSocket, ui);
     // }
     this.activityManager.setActivity(userId, ui);
-    console.log(clientSocket.request.headers);
+    // console.log(clientSocket.request.headers);
   }
 }

--- a/backend/src/user/user.gateway.ts
+++ b/backend/src/user/user.gateway.ts
@@ -1,0 +1,50 @@
+import { Server } from 'socket.io';
+import {
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+
+import { Activity, UserId } from '../util/type';
+import { ActivityManager } from '../user-status/activity.manager';
+import { UserRelationshipStorage } from '../user-status/user-relationship.storage';
+
+@WebSocketGateway()
+export class UserGateway {
+  @WebSocketServer()
+  private server: Server;
+
+  constructor(
+    private activityManager: ActivityManager,
+    private userRelationshipStorage: UserRelationshipStorage,
+  ) {}
+
+  /**
+   * @description activity & relationship 정보 전달
+   *
+   * @param requesterId 요청한 유저의 id
+   * @param requestedId 요청받은 유저의 id
+   */
+  @SubscribeMessage('message')
+  emitUserInfo(requesterId: UserId, requestedId: UserId) {
+    let activity: Activity = 'offline';
+    const currentUi = this.activityManager.getActivity(requestedId);
+    if (currentUi) {
+      activity = currentUi === 'playingGame' ? 'inGame' : 'online';
+    }
+
+    // TODO : 게임 중이라면 GameStorage 에서 gameId 가져오기
+    const gameId = null;
+
+    const relationship =
+      this.userRelationshipStorage.getRelationship(requesterId, requestedId) ??
+      'normal';
+
+    this.server.emit('userInfo', {
+      activity,
+      gameId,
+      relationship,
+      userId: requestedId,
+    });
+  }
+}

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { UserGateway } from './user.gateway';
+import { UserStatusModule } from '../user-status/user-status.module';
+
+@Module({
+  imports: [UserStatusModule],
+  providers: [UserGateway],
+})
+export class UserModule {}

--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -37,3 +37,12 @@ export type CurrentUi =
   | 'ranks'
   | 'watchingGame'
   | 'waitingRoom';
+
+export type Activity = 'online' | 'offline' | 'inGame';
+
+export interface UserInfoMessage {
+  activity: Activity;
+  gameId: number;
+  relationship: Relationship;
+  userId: UserId;
+}

--- a/backend/test/activity-gateway.e2e-spec.ts
+++ b/backend/test/activity-gateway.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common';
+import { Socket, io } from 'socket.io-client';
 import { Test, TestingModule } from '@nestjs/testing';
-import { io, Socket } from 'socket.io-client';
 
 import { ActivityManager } from '../src/user-status/activity.manager';
 import { AppModule } from '../src/app.module';

--- a/backend/test/mock.repositories.ts
+++ b/backend/test/mock.repositories.ts
@@ -1,0 +1,42 @@
+import { UserId } from '../src/util/type';
+
+export const mockUsersRepositoryFactory = (entities: any[]) => {
+  return {
+    find: jest.fn().mockResolvedValue(entities),
+    findOne: jest
+      .fn()
+      .mockImplementation((userId: number) =>
+        entities.find((user) => user.userId === userId),
+      ),
+  };
+};
+export const mockFriendsRepositoryFactory = (entities: any[]) => {
+  return {
+    find: jest.fn().mockResolvedValue(entities),
+    findBy: jest
+      .fn()
+      .mockImplementation(
+        (options: [{ senderId: UserId }, { receiverId: UserId }]) =>
+          entities.filter(
+            ({ senderId, receiverId }) =>
+              options[0].senderId === senderId ||
+              options[1].receiverId === receiverId,
+          ),
+      ),
+  };
+};
+export const mockBlockedUsersRepositoryFactory = (entities: any[]) => {
+  return {
+    find: jest.fn().mockResolvedValue(entities),
+    findBy: jest
+      .fn()
+      .mockImplementation(
+        (options: [{ blockerId: UserId }, { blockedId: UserId }]) =>
+          entities.filter(
+            ({ blockerId, blockedId }) =>
+              options[0].blockerId === blockerId ||
+              options[1].blockedId === blockedId,
+          ),
+      ),
+  };
+};

--- a/backend/test/mock.repositories.ts
+++ b/backend/test/mock.repositories.ts
@@ -10,6 +10,7 @@ export const mockUsersRepositoryFactory = (entities: any[]) => {
       ),
   };
 };
+
 export const mockFriendsRepositoryFactory = (entities: any[]) => {
   return {
     find: jest.fn().mockResolvedValue(entities),
@@ -25,6 +26,7 @@ export const mockFriendsRepositoryFactory = (entities: any[]) => {
       ),
   };
 };
+
 export const mockBlockedUsersRepositoryFactory = (entities: any[]) => {
   return {
     find: jest.fn().mockResolvedValue(entities),

--- a/backend/test/user-gateway.e2e-spec.ts
+++ b/backend/test/user-gateway.e2e-spec.ts
@@ -1,0 +1,234 @@
+import { INestApplication } from '@nestjs/common';
+import { Socket, io } from 'socket.io-client';
+import { Test, TestingModule } from '@nestjs/testing';
+import { faker } from '@faker-js/faker';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import waitForExpect from 'wait-for-expect';
+
+import { ActivityManager } from './../src/user-status/activity.manager';
+import { AppModule } from '../src/app.module';
+import { BlockedUsers } from './../src/entity/blocked-users.entity';
+import { Friends } from './../src/entity/friends.entity';
+import { UserId, UserInfoMessage } from './../src/util/type';
+import { Users } from './../src/entity/users.entity';
+import { UserGateway } from './../src/user/user.gateway';
+import {
+  generateUsers,
+  generateFriends,
+  generateBlockedUsers,
+} from './generate-mock-data';
+import {
+  mockBlockedUsersRepositoryFactory,
+  mockFriendsRepositoryFactory,
+  mockUsersRepositoryFactory,
+} from './mock.repositories';
+
+enum Relationships {
+  NORMAL,
+  FRIEND,
+  BLOCKED,
+}
+
+const ONLINE = true;
+const OFFLINE = false;
+
+describe('UserStatusModule (e2e)', () => {
+  let app: INestApplication;
+  let requesterSocket: Socket;
+  let requestedSocket: Socket;
+  let usersEntities: Users[];
+  let gateway: UserGateway;
+  let activityManager: ActivityManager;
+
+  beforeAll(async () => {
+    usersEntities = generateUsers(100);
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(getRepositoryToken(Users))
+      .useValue(mockUsersRepositoryFactory(usersEntities))
+      .overrideProvider(getRepositoryToken(Friends))
+      .useValue(
+        mockFriendsRepositoryFactory(
+          generateFriends(usersEntities.slice(40, 70)),
+        ),
+      )
+      .overrideProvider(getRepositoryToken(BlockedUsers))
+      .useValue(
+        mockBlockedUsersRepositoryFactory(
+          generateBlockedUsers(usersEntities.slice(70, 100)),
+        ),
+      )
+      .compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    await app.listen(4244);
+    gateway = moduleFixture.get(UserGateway);
+    activityManager = moduleFixture.get(ActivityManager);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : emitUserInfo                                                    *
+   *                                                                           *
+   ****************************************************************************/
+
+  describe('emitUserInfo', () => {
+    afterEach(() => {
+      requesterSocket.close();
+      requestedSocket?.close();
+    });
+
+    it('should send online & normal for self', async () => {
+      const clients = await createClients(
+        usersEntities,
+        OFFLINE,
+        Relationships.NORMAL,
+      );
+      const requesterId = clients[0].id;
+      const requestedId = clients[0].id;
+      requesterSocket = clients[0].socket;
+      await waitForExpect(() =>
+        expect(activityManager.getActivity(requesterId)).not.toBeNull(),
+      );
+      gateway.emitUserInfo(requesterId, requestedId);
+      const data: UserInfoMessage = await new Promise((resolve) =>
+        requesterSocket.on('userInfo', (data) => resolve(data)),
+      );
+      expect(data).toEqual({
+        activity: 'online',
+        gameId: null,
+        relationship: 'normal',
+        userId: requestedId,
+      });
+    });
+
+    it('should send offline & normal', async () => {
+      const clients = await createClients(
+        usersEntities,
+        OFFLINE,
+        Relationships.NORMAL,
+      );
+      const requesterId = clients[0].id;
+      const requestedId = clients[1].id;
+      requesterSocket = clients[0].socket;
+      await waitForExpect(() =>
+        expect(activityManager.getActivity(requesterId)).not.toBeNull(),
+      );
+      gateway.emitUserInfo(requesterId, requestedId);
+      const data = await new Promise((resolve) =>
+        requesterSocket.on('userInfo', (data) => resolve(data)),
+      );
+      expect(data).toEqual({
+        activity: 'offline',
+        gameId: null,
+        relationship: 'normal',
+        userId: requestedId,
+      });
+    });
+
+    it('should send online & blocked | blocker', async () => {
+      const clients = await createClients(
+        usersEntities,
+        ONLINE,
+        Relationships.BLOCKED,
+      );
+      const requesterId = clients[0].id;
+      const requestedId = clients[1].id;
+      requesterSocket = clients[0].socket;
+      requestedSocket = clients[1].socket;
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(requesterId)).not.toBeNull();
+        expect(activityManager.getActivity(requestedId)).not.toBeNull();
+      });
+      gateway.emitUserInfo(requesterId, requestedId);
+      const { activity, gameId, relationship, userId }: UserInfoMessage =
+        await new Promise((resolve) =>
+          requesterSocket.on('userInfo', (data) => resolve(data)),
+        );
+      expect(activity).toEqual('online');
+      expect(gameId).toEqual(null);
+      expect(['blocked', 'blocker'].includes(relationship)).toBeTruthy();
+      expect(userId).toEqual(requestedId);
+    });
+
+    it('should send online & pendingSender | pendingRequester | friend', async () => {
+      const clients = await createClients(
+        usersEntities,
+        ONLINE,
+        Relationships.FRIEND,
+      );
+      const requesterId = clients[0].id;
+      const requestedId = clients[1].id;
+      requesterSocket = clients[0].socket;
+      requestedSocket = clients[1].socket;
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(requesterId)).not.toBeNull();
+        expect(activityManager.getActivity(requestedId)).not.toBeNull();
+      });
+      gateway.emitUserInfo(requesterId, requestedId);
+      const { activity, gameId, relationship, userId }: UserInfoMessage =
+        await new Promise((resolve) =>
+          requesterSocket.on('userInfo', (data) => resolve(data)),
+        );
+      expect(activity).toEqual('online');
+      expect(gameId).toEqual(null);
+      expect(
+        ['pendingSender', 'pendingReceiver', 'friend'].includes(relationship),
+      ).toBeTruthy();
+      expect(userId).toEqual(requestedId);
+    });
+
+    // TODO : add tests for inGame
+  });
+});
+
+/*****************************************************************************
+ *                                                                           *
+ * SECTION : Utils                                                           *
+ *                                                                           *
+ ****************************************************************************/
+
+const connectClient = async (userId: UserId, ui = 'profile') => {
+  const socket = io('http://localhost:4244', {
+    extraHeaders: { 'x-user-id': userId.toString() },
+  });
+  await new Promise((resolve) => socket.on('connect', () => resolve('done')));
+  socket.emit('currentUi', { userId, ui });
+  return socket;
+};
+
+const createClients = async (
+  usersEntities: Users[],
+  isRequestedOnline: boolean,
+  relationship: Relationships,
+) => {
+  const [first, second] = (() => {
+    switch (relationship) {
+      case Relationships.NORMAL:
+        return [
+          faker.helpers.unique(faker.datatype.number, [{ min: 0, max: 39 }]),
+          faker.helpers.unique(faker.datatype.number, [{ min: 0, max: 39 }]),
+        ];
+      case Relationships.FRIEND:
+        return faker.datatype.boolean() ? [40, 41] : [43, 42];
+      case Relationships.BLOCKED:
+        return faker.datatype.boolean() ? [70, 71] : [73, 72];
+      default:
+    }
+  })();
+  const clientIds = [usersEntities[first].userId, usersEntities[second].userId];
+  const requester = await connectClient(clientIds[0], 'profile');
+  let requested: Socket;
+  if (isRequestedOnline) {
+    requested = await connectClient(clientIds[1], 'profile');
+  }
+  return [
+    { id: clientIds[0], socket: requester },
+    { id: clientIds[1], socket: requested ?? null },
+  ];
+};


### PR DESCRIPTION
## 개요
- #65
- UserGateway userInfo 이벤트 emitter 구현 (gameId 제외).
- 아직 작업중인 브랜치이니 merge 후 삭제하지 말아주세요.

## 작업 사항
- `userComponent` 에서 activity 표시와 관계 표시를 위해 서버에서 보내는 userInfo event emit 하는 메소드 구현.
- 가벼운 테스트를 위해 DB 연결 대신 mock repository 들 구현.
- 소켓 연결 끊어질 때 ActivityMap 에서 유저 activity 삭제.