### PR TITLE
✨ feat : chat WS 이벤트 핸들링 하는 ChatsGateway 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UserModule } from './user/user.module';
 import { UserStatusModule } from './user-status/user-status.module';
+import { ChatsModule } from './chats/chats.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { UserStatusModule } from './user-status/user-status.module';
         apiConfigService.postgresConfig,
       inject: [ApiConfigService],
     }),
+    ChatsModule,
     UserModule,
     UserStatusModule,
   ],

--- a/backend/src/chats/chats.gateway.ts
+++ b/backend/src/chats/chats.gateway.ts
@@ -1,0 +1,173 @@
+import { DateTime } from 'luxon';
+import { Server } from 'socket.io';
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+
+import { ChannelId, SocketId, UserId, UserRole } from '../util/type';
+import { UserSocketStorage } from '../user-status/user-socket.storage';
+
+// TODO : service 에서 member 가 아닌 유저가 채팅방 관련 이벤트를 보내는 경우 처리
+// TODO : unseenCount 어디서 처리할지 고민
+@WebSocketGateway()
+export class ChatsGateway {
+  @WebSocketServer()
+  private server: Server;
+
+  constructor(private userSocketStorage: UserSocketStorage) {}
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Public methods                                                  *
+   *                                                                           *
+   ****************************************************************************/
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Managing Room                                                  *
+   *                                                                           *
+   ****************************************************************************/
+
+  /**
+   * @description 채팅방 입장시 해당 Room 에 join
+   *
+   * @param roomId 유저의 socket id
+   * @param room 현재 보고있는 채팅방의 room ui
+   */
+  joinRoom(socketId: SocketId, room: `chatRooms-${ChannelId}`) {
+    this.server.in(socketId).socketsJoin(room);
+  }
+
+  /**
+   * @description 채팅방 UI 에 유저가 머무를 시 해당 activeChatRoom 에 join
+   *
+   * @param socketId 유저의 socket id
+   * @param channelId 유저가 머무르는 채팅방의 id
+   */
+  joinActiveRoom(socketId: SocketId, room: `chatRooms-${ChannelId}`) {
+    this.server.in(socketId).socketsJoin(room + '-active');
+  }
+
+  /**
+   * @description 채팅방 UI 에서 나갈 시 해당 Room 에서 leave
+   *
+   * @param socketId 유저의 socket id
+   * @param channelId 유저가 머무르던 채팅방의 id
+   */
+  leaveActiveRoom(socketId: SocketId, room: `chatRooms-${ChannelId}`) {
+    this.server.in(socketId).socketsLeave(room + '-active');
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Events when user does viewing the chatRoom-UI                   *
+   *                                                                           *
+   ****************************************************************************/
+
+  /**
+   * @description 새로운 멤버가 채팅방에 입장했을 때, 해당 채팅방을 보고 있는 모든 멤버에게 알림
+   *
+   * @param userId 입장한 유저의 id
+   * @param channelId 입장한 채팅방의 id
+   */
+  emitMemberJoin(joinedMember: UserId, channelId: ChannelId) {
+    this.server
+      .in(`chatRooms-${channelId}-active`)
+      .emit('memberJoin', { joinedMember });
+  }
+
+  /**
+   * @description 새로운 메시지가 채팅방에 도착했을 때, 해당 채팅방을 보고 있는 모든 멤버에게 알림
+   *
+   * @param userId 메시지를 보낸 유저의 id
+   * @param channelId 메시지를 보낸 채팅방의 id
+   * @param content 메시지 내용
+   * @param sentAt 메시지 작성 시간
+   */
+  emitNewMessage(
+    senderId: UserId,
+    channelId: ChannelId,
+    content: string,
+    sentAt: DateTime,
+  ) {
+    this.server
+      .in(`chatRooms-${channelId}-active`)
+      .emit('newMessage', { senderId, content, sentAt });
+    // TODO: 여기서 emit 하는게 맞는 지 고민해보기
+    this.emitMessageArrived(channelId);
+  }
+
+  /**
+   * @description 멤버가 채팅방에서 나갔을 때, 해당 채팅방을 보고 있는 모든 멤버에게 알림
+   *
+   * @param userId 나간 멤버의 id
+   * @param channelId 나간 채팅방의 id
+   * @param isOwner 나간 멤버가 채팅방의 owner 인지 여부
+   */
+  emitMemberLeft(leftMember: UserId, channelId: ChannelId, isOwner: boolean) {
+    this.server
+      .in(`chatRooms-${channelId}-active`)
+      .emit('memberLeft', { leftMember, isOwner });
+  }
+
+  /**
+   * @description 멤버의 역할이 변경되었을 때, 해당 채팅방을 보고 있는 모든 멤버에게 알림
+   *
+   * @param changedMember 역할이 변경된 멤버의 id
+   * @param channelId 역할이 변경된 채팅방의 id
+   * @param newRole 새로운 역할
+   */
+  emitRoleChanged(
+    changedMember: UserId,
+    channelId: ChannelId,
+    newRole: Exclude<UserRole, 'owner'>,
+  ) {
+    this.server
+      .in(`chatRooms-${channelId}-active`)
+      .emit('roleChanged', { changedMember, newRole });
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Events when user does not viewing the chatRoom-UI               *
+   *                                                                           *
+   ****************************************************************************/
+
+  /**
+   * @description 새로운 메시지가 도착 했을 때, 해당 채팅방을 보고 있지 않은 멤버에게 알림
+   *
+   * @param channelId 채팅방의 id
+   */
+  // TODO: unseenCount 생각하기, private 로 바꿀지 생각하기
+  emitMessageArrived(channelId: ChannelId) {
+    this.server
+      .in(`chatRooms-${channelId}`)
+      .except(`chatRooms-${channelId}-active`)
+      .emit('messageArrived', { channelId });
+  }
+
+  /**
+   * @description 멤버가 채팅방에서 mute 되었을 때, 해당 유저에게 알림
+   *
+   * @param mutedMember mute 된 멤버의 id
+   * @param channelId mute 된 채팅방의 id
+   * @param muteEndAt mute 가 해제되는 시간
+   */
+  emitMuted(mutedMember: UserId, channelId: ChannelId, muteEndAt: DateTime) {
+    const socketId = this.userSocketStorage.clients.get(mutedMember);
+    if (socketId) {
+      this.server.in(socketId).emit('muted', {
+        mutedMember,
+        channelId,
+        muteEndAt,
+      });
+    }
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * NOTE : test Only (maybe)                                                  *
+   *                                                                           *
+   ****************************************************************************/
+  getRoomMembers(chatRoom: string) {
+    return this.server.sockets.adapter.rooms.get(chatRoom);
+  }
+}

--- a/backend/src/chats/chats.interface.ts
+++ b/backend/src/chats/chats.interface.ts
@@ -1,0 +1,28 @@
+import { DateTime } from 'luxon';
+
+import { ChannelId, UserId, UserRole } from '../util/type';
+
+export interface MemberJoinedMessage {
+  joinedMember: UserId;
+}
+
+export interface NewMessage {
+  senderId: UserId;
+  content: string;
+  sentAt: DateTime;
+}
+
+export interface LeftMessage {
+  leftMember: UserId;
+  isOwner: boolean;
+}
+
+export interface RoleChangedMessage {
+  changedMember: UserId;
+  newRole: Exclude<UserRole, 'owner'>;
+}
+
+export interface MutedMessage {
+  channelId: ChannelId;
+  muteEndAt: DateTime;
+}

--- a/backend/src/chats/chats.module.ts
+++ b/backend/src/chats/chats.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { ChatsGateway } from './chats.gateway';
+import { UserStatusModule } from '../user-status/user-status.module';
+
+@Module({
+  imports: [UserStatusModule],
+  providers: [ChatsGateway],
+  exports: [ChatsGateway],
+})
+export class ChatsModule {}

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -12,6 +12,7 @@ import { UsePipes, ValidationPipe } from '@nestjs/common';
 
 import { ActivityManager } from './activity.manager';
 import { ChannelStorage } from './channel.storage';
+import { ChatsGateway } from '../chats/chats.gateway';
 import { CurrentUiDto } from './dto/current-ui.dto';
 import { UserRelationshipStorage } from './user-relationship.storage';
 import { UserSocketStorage } from './user-socket.storage';
@@ -35,12 +36,11 @@ export class ActivityGateway
     private userRelationshipStorage: UserRelationshipStorage,
     private userSocketStorage: UserSocketStorage,
     private channelStorage: ChannelStorage,
+    private chatsGateway: ChatsGateway,
   ) /**
    * private authService: AuthService,
    * private gameGateway: GameGateway,
-   * private chatsGateway: ChatsGateway,
-   * private ranksGateway: RanksGateway,
-   */ {}
+   * private ranksGateway: RanksGateway, */ {}
 
   async handleConnection(clientSocket: Socket) {
     // const accessToken = clientSocket.handshake.headers.cookie
@@ -90,6 +90,23 @@ export class ActivityGateway
     // } else if (/chatRooms-\d+/.test(ui)) {
     //   this.chatsGateway.joinRoom(clientSocket, ui);
     // }
+    const prevActivity = this.activityManager.getActivity(userId);
+    if (prevActivity && prevActivity.startsWith('chatRooms-')) {
+      this.chatsGateway.leaveActiveRoom(
+        clientSocket.id,
+        prevActivity as `chatRooms-${number}`,
+      );
+    }
+    if (ui.startsWith('chatRooms-')) {
+      const room = ui as `chatRooms-${number}`;
+      this.channelStorage.updateUnseenCount(
+        Number(room.split('-')[1]),
+        userId,
+        true,
+      );
+      this.chatsGateway.joinActiveRoom(clientSocket.id, room);
+      this.chatsGateway.joinRoom(clientSocket.id, room);
+    }
     this.activityManager.setActivity(userId, ui);
     // console.log(clientSocket.request.headers);
   }

--- a/backend/src/user-status/user-status.module.ts
+++ b/backend/src/user-status/user-status.module.ts
@@ -8,6 +8,7 @@ import { BlockedUsers } from '../entity/blocked-users.entity';
 import { ChannelMembers } from '../entity/channel-members.entity';
 import { ChannelStorage } from './channel.storage';
 import { Channels } from '../entity/channels.entity';
+import { ChatsGateway } from '../chats/chats.gateway';
 import { Friends } from '../entity/friends.entity';
 import { Messages } from '../entity/messages.entity';
 import { UserRelationshipStorage } from './user-relationship.storage';
@@ -29,6 +30,7 @@ import { Users } from '../entity/users.entity';
   providers: [
     ActivityGateway,
     ActivityManager,
+    ChatsGateway,
     ChannelStorage,
     UserRelationshipStorage,
     UserSocketStorage,

--- a/backend/test/chats-gateway.e2e-spec.ts
+++ b/backend/test/chats-gateway.e2e-spec.ts
@@ -1,0 +1,378 @@
+import { DateTime } from 'luxon';
+import { INestApplication } from '@nestjs/common';
+import { Socket, io } from 'socket.io-client';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AppModule } from '../src/app.module';
+import { ChannelMembers } from './../src/entity/channel-members.entity';
+import { Channels } from './../src/entity/channels.entity';
+import { ChatsGateway } from './../src/chats/chats.gateway';
+import {
+  LeftMessage,
+  MemberJoinedMessage,
+  MutedMessage,
+  NewMessage,
+  RoleChangedMessage,
+} from './../src/chats/chats.interface';
+import { Users } from './../src/entity/users.entity';
+import {
+  createChannelMember,
+  generateUsers,
+  generateChannels,
+} from './generate-mock-data';
+
+describe('UserStatusModule (e2e)', () => {
+  let app: INestApplication;
+  let chatsGateway: ChatsGateway;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    await app.listen(4245);
+
+    chatsGateway = moduleFixture.get(ChatsGateway);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  let users: Users[];
+  let channel: Channels;
+  let channelMembers: ChannelMembers[];
+  let clientSockets: Socket[];
+
+  beforeEach(async () => {
+    users = generateUsers(3);
+    channel = generateChannels([users[0]])[0];
+    channel.channelId = 1;
+    channelMembers = [
+      createChannelMember(users[0].userId, channel.channelId, true),
+    ];
+    clientSockets = users.map((user) => {
+      return io('http://localhost:4245', {
+        extraHeaders: {
+          'x-user-id': user.userId.toString(),
+        },
+      });
+    });
+    await Promise.all(
+      clientSockets.map(
+        (clientSocket) =>
+          new Promise((resolve) =>
+            clientSocket.on('connect', () => resolve('done')),
+          ),
+      ),
+    );
+  });
+
+  afterEach(async () => {
+    users = [];
+    channel = null;
+    channelMembers = [];
+    for (const clientSocket of clientSockets) {
+      clientSocket.close();
+    }
+  });
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : join Rooms                                                      *
+   *                                                                           *
+   ****************************************************************************/
+  it('should join room', async () => {
+    // case: users are member of the chatRooms-1
+    // when: users join the chatRooms-1 UI
+    // then: users should join the chatRooms-1
+    clientSockets.forEach((clientSocket, index) => {
+      clientSocket.emit('currentUi', {
+        userId: users[index].userId,
+        ui: `chatRooms-${channel.channelId}`,
+      });
+    });
+    await new Promise((resolve) => setTimeout(() => resolve('done'), 1000));
+    expect(
+      chatsGateway.getRoomMembers(`chatRooms-${channel.channelId}`).size,
+    ).toBe(3);
+    clientSockets.forEach((clientSocket) =>
+      expect(
+        chatsGateway
+          .getRoomMembers(`chatRooms-${channel.channelId}`)
+          .has(clientSocket.id),
+      ).toBeTruthy(),
+    );
+
+    expect(
+      chatsGateway.getRoomMembers(`chatRooms-${channel.channelId}-active`).size,
+    ).toBe(3);
+    clientSockets.forEach((clientSocket) =>
+      expect(
+        chatsGateway
+          .getRoomMembers(`chatRooms-${channel.channelId}-active`)
+          .has(clientSocket.id),
+      ).toBeTruthy(),
+    );
+  });
+
+  it('should join chatRoom but not in chatRoom-activity', async () => {
+    // case: users are join the chatRooms-1
+    // when: user[1] visits the profile UI
+    // then: user[1] should join the chatRooms-1 but not in chatRoom-activity
+    clientSockets.forEach((clientSocket, index) => {
+      clientSocket.emit('currentUi', {
+        userId: users[index].userId,
+        ui: `chatRooms-${channel.channelId}`,
+      });
+    });
+    clientSockets[1].emit('currentUi', {
+      userId: users[1].userId,
+      ui: 'profile',
+    });
+    await new Promise((resolve) => setTimeout(() => resolve('done'), 1000));
+    expect(
+      chatsGateway.getRoomMembers(`chatRooms-${channel.channelId}`).size,
+    ).toBe(3);
+    clientSockets.forEach((clientSocket) =>
+      expect(
+        chatsGateway
+          .getRoomMembers(`chatRooms-${channel.channelId}`)
+          .has(clientSocket.id),
+      ).toBeTruthy(),
+    );
+
+    expect(
+      chatsGateway.getRoomMembers(`chatRooms-${channel.channelId}-active`).size,
+    ).toBe(2);
+    clientSockets.forEach((clientSocket, index) => {
+      expect(
+        chatsGateway
+          .getRoomMembers(`chatRooms-${channel.channelId}-active`)
+          .has(clientSocket.id),
+      ).toBe(index !== 1);
+    });
+  });
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : events in chatRoom                                              *
+   *                                                                           *
+   ****************************************************************************/
+  it('should send a memberJoined event to the chatRoom', async () => {
+    // case: users[0] is member of chat,
+    //   users[1] is not member of chat but will join,
+    //   users[2] is member of chat but not viewing chatRoom-1
+    // when: users[0] views chatRoom-1 UI, users[1] join chatRoom-1
+    // then: users[0] got memberJoined event,
+    //   users[2] did not get memberJoined event
+    clientSockets.forEach((clientSocket, index) => {
+      clientSocket.emit('currentUi', {
+        userId: users[index].userId,
+        ui: `chatRooms-${channel.channelId}`,
+      });
+    });
+    clientSockets[2].emit('currentUi', {
+      userId: users[2].userId,
+      ui: `profile`,
+    });
+    await new Promise((resolve) => setTimeout(() => resolve('done'), 1000));
+    chatsGateway.emitMemberJoin(users[1].userId, channel.channelId);
+    const joinMsg = await new Promise<MemberJoinedMessage>((resolve) =>
+      clientSockets[0].on('memberJoin', (data) => resolve(data)),
+    );
+    expect(joinMsg).toEqual({ joinedMember: users[1].userId });
+
+    timeout(
+      1000,
+      new Promise<MemberJoinedMessage>((resolve) =>
+        clientSockets[2].on('memberJoin', (data) => resolve(data)),
+      ),
+    )
+      .then((data) => expect(data).toBeUndefined())
+      .catch((err) => expect(err).toBe('timeout'));
+  });
+
+  it('should send newMessage and messageArrived events to appropriate users', async () => {
+    // case: users are member of chat
+    //   and user[0] and user[1] are viewing chatRoom-1, user[2] is not
+    // when: users[0] write message
+    // then: users[0] got newMessage event and users[1] got messageArrived event
+    clientSockets.forEach((clientSocket, index) => {
+      clientSocket.emit('currentUi', {
+        userId: users[index].userId,
+        ui: `chatRooms-${channel.channelId}`,
+      });
+    });
+    clientSockets[2].emit('currentUi', {
+      userId: users[2].userId,
+      ui: `chatRooms-${channel.channelId + 1}`,
+    });
+    const sentMsg: NewMessage = {
+      senderId: users[0].userId,
+      content: 'nice to meet you',
+      sentAt: DateTime.now(),
+    };
+    await new Promise((resolve) => setTimeout(() => resolve('done'), 1000));
+    chatsGateway.emitNewMessage(
+      sentMsg.senderId,
+      channel.channelId,
+      sentMsg.content,
+      sentMsg.sentAt,
+    );
+    const recvMsg = await Promise.all([
+      new Promise<NewMessage>((resolve) =>
+        clientSockets[0].on('newMessage', (msg) => resolve(msg)),
+      ),
+      new Promise<NewMessage>((resolve) =>
+        clientSockets[1].on('newMessage', (msg) => resolve(msg)),
+      ),
+    ]);
+    sentMsg.sentAt = sentMsg.sentAt.toString() as any;
+    expect(recvMsg[0]).toEqual(recvMsg[1]);
+    expect(recvMsg[1]).toEqual(sentMsg);
+    expect(
+      await new Promise<{ channelId: number }>((resolve) =>
+        clientSockets[2].on('messageArrived', (msg) => resolve(msg)),
+      ),
+    ).toEqual({ channelId: channel.channelId });
+  });
+
+  it('should send a memberLeft event to the chatRoom', async () => {
+    // case: users are member of chat and are viewing chatRoom-1 UI
+    // when: user[2] leave chatRoom-1
+    // then: remaining users got memberLeft event
+    channelMembers.push(
+      createChannelMember(users[1].userId, channel.channelId),
+      createChannelMember(users[2].userId, channel.channelId),
+    );
+
+    clientSockets.forEach((clientSocket, index) => {
+      clientSocket.emit('currentUi', {
+        userId: users[index].userId,
+        ui: `chatRooms-${channel.channelId}`,
+      });
+    });
+    const { memberId, channelId, isAdmin } = channelMembers[2];
+
+    await new Promise((resolve) => setTimeout(() => resolve('done'), 1000));
+    chatsGateway.emitMemberLeft(memberId, channelId, isAdmin);
+    const leftMsg = await Promise.all([
+      new Promise<LeftMessage>((resolve) =>
+        clientSockets[0].on('memberLeft', (msg) => resolve(msg)),
+      ),
+      new Promise<LeftMessage>((resolve) =>
+        clientSockets[1].on('memberLeft', (msg) => resolve(msg)),
+      ),
+    ]);
+    expect(leftMsg[0]).toEqual(leftMsg[1]);
+    expect(leftMsg[1]).toEqual({
+      leftMember: memberId,
+      isOwner: isAdmin,
+    });
+  });
+
+  it('should send a roleChanged event to the chatRoom', async () => {
+    // case: users are member of chat and are viewing chatRoom-1 UI
+    // when: the role of user[2] is changed (member -> admin)
+    // then: All users got roleChanged event
+
+    channelMembers.push(
+      createChannelMember(users[1].userId, channel.channelId),
+      createChannelMember(users[2].userId, channel.channelId),
+    );
+
+    clientSockets.forEach((clientSocket, index) => {
+      clientSocket.emit('currentUi', {
+        userId: users[index].userId,
+        ui: `chatRooms-${channel.channelId}`,
+      });
+    });
+    const { memberId, channelId } = channelMembers[2];
+
+    await new Promise((resolve) => setTimeout(() => resolve('done'), 1000));
+    chatsGateway.emitRoleChanged(memberId, channelId, 'admin');
+    const msg = await Promise.all(
+      clientSockets.map(
+        (clientSocket) =>
+          new Promise<RoleChangedMessage>((resolve) =>
+            clientSocket.on('roleChanged', (msg) => resolve(msg)),
+          ),
+      ),
+    );
+    expect(msg[0]).toEqual(msg[1]);
+    expect(msg[1]).toEqual(msg[2]);
+    expect(msg[2]).toEqual({
+      changedMember: memberId,
+      newRole: 'admin',
+    });
+  });
+
+  it('should send a muted event to the user', async () => {
+    // case: users are member of chat and are viewing chatRoom-1 UI
+    // when: user[2] is muted
+    // then: user[2] got muted event, other users got nothing
+
+    channelMembers.push(
+      createChannelMember(users[1].userId, channel.channelId),
+      createChannelMember(users[2].userId, channel.channelId),
+    );
+
+    clientSockets.forEach((clientSocket, index) => {
+      clientSocket.emit('currentUi', {
+        userId: users[index].userId,
+        ui: `chatRooms-${channel.channelId}`,
+      });
+    });
+    const { memberId, channelId } = channelMembers[2];
+    const muteEndAt = DateTime.now().plus({ minutes: 10 });
+
+    await new Promise((resolve) => setTimeout(() => resolve('done'), 1000));
+    chatsGateway.emitMuted(memberId, channelId, muteEndAt);
+    const msg = await new Promise<MutedMessage>((resolve) =>
+      clientSockets[2].on('muted', (msg) => resolve(msg)),
+    );
+    expect(msg).toEqual({
+      mutedMember: memberId,
+      channelId,
+      muteEndAt: muteEndAt.toString(),
+    });
+
+    timeout(
+      1000,
+      new Promise<MutedMessage>((resolve) =>
+        clientSockets[0].on('muted', (data) => resolve(data)),
+      ),
+    )
+      .then((data) => expect(data).toBeUndefined())
+      .catch((err) => expect(err).toBe('timeout'));
+
+    timeout(
+      1000,
+      new Promise<MutedMessage>((resolve) =>
+        clientSockets[1].on('muted', (data) => resolve(data)),
+      ),
+    )
+      .then((data) => expect(data).toBeUndefined())
+      .catch((err) => expect(err).toBe('timeout'));
+  });
+});
+
+async function timeout<T>(ms: number, promise: Promise<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject('timeout');
+    }, ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## 개요
- #71 작업

## 작업 사항
- ChatsGateway 에서 ActivityGateway 를 통한 Room 관리
  - 채팅방의 멤버를 관리하는 `chatRooms-${channelId}` , 채팅방 UI 를 보고있는 멤버를 관리하는 `chatRooms-${channelId}-active` rooms 를 만들어서 접속 시 멤버들을 room 에 추가
  - 채팅방 UI 에서 다른 UI 로 이동 시 `chatRooms-${channelId}-active` room 에서 제외
  - 로그인 후 채팅방 UI 에 접속하기 전 Room 관리는 구현 미완료(까먹었습니다...)
- chats interface 파일 생성 및 interface 선언
- ActivityGateway 에서 유저가 특정 채팅방에 접속 시 ChannelStorage 를 통한 unseenCount 초기화

## 변경점
- ActivityGateway 의 handleConnection 메소드에서 chats socket Room 에 넣는 로직 추가

--- 

- unseenCount 나 ActivityGateway 와 함께 작동하는 부분은 보완이 필요합니다.
- 각종 validation 이 필요한 부분은 service 구현까지 가봐야 가닥이 잡힐 듯 싶어서 주석만 달아뒀습니다.
- #71 은 제가 내일 한번 더 검토해보고 직접 닫겠습니다.