### PR TITLE
✨ feat : userComponent & friendsToggle 관련 WS 이벤트 핸들링하는 UserGateway 객체 구현

### DIFF
--- a/backend/src/user/dto/user-info.dto.ts
+++ b/backend/src/user/dto/user-info.dto.ts
@@ -1,8 +1,0 @@
-import { Activity, Relationship, UserId } from '../../util/type';
-
-export interface UserInfoDto {
-  activity: Activity;
-  gameId: number;
-  relationship: Relationship | 'normal';
-  userId: UserId;
-}

--- a/backend/src/user/dto/user-info.dto.ts
+++ b/backend/src/user/dto/user-info.dto.ts
@@ -1,0 +1,8 @@
+import { Activity, Relationship, UserId } from '../../util/type';
+
+export interface UserInfoDto {
+  activity: Activity;
+  gameId: number;
+  relationship: Relationship | 'normal';
+  userId: UserId;
+}

--- a/backend/src/user/dto/user.dto.ts
+++ b/backend/src/user/dto/user.dto.ts
@@ -1,0 +1,36 @@
+import { Activity, Relationship, UserId } from '../../util/type';
+
+export interface UserInfoDto {
+  activity: Activity;
+  gameId: number;
+  relationship: Relationship | 'normal';
+  userId: UserId;
+}
+
+export interface FriendAcceptedDto {
+  newFriendId: UserId;
+}
+
+export interface FriendDeclinedDto {
+  declinedBy: UserId;
+}
+
+export interface FriendCancelledDto {
+  cancelledBy: UserId;
+}
+
+export interface PendingFriendRequestDto {
+  isPending: boolean;
+}
+
+export interface FriendRemovedDto {
+  removedBy: UserId;
+}
+
+export interface BlockedDto {
+  blockedBy: UserId;
+}
+
+export interface UnblockedDto {
+  unblockedBy: UserId;
+}

--- a/backend/src/user/user.gateway.ts
+++ b/backend/src/user/user.gateway.ts
@@ -19,11 +19,11 @@ export class UserGateway {
   /**
    * @description activity & relationship 정보 전달
    *
-   * @param socketId 요청한 유저의 socket id
+   * @param requesterSocketId 요청한 유저의 socket id
    * @param userInfo 요청한 유저의 activity & relationship 정보
    */
-  emitUserInfo(socketId: SocketId, userInfo: UserInfoDto) {
-    this.server.to(socketId).emit('userInfo', userInfo);
+  emitUserInfo(requesterSocketId: SocketId, userInfo: UserInfoDto) {
+    this.server.to(requesterSocketId).emit('userInfo', userInfo);
   }
 
   /*****************************************************************************

--- a/backend/src/user/user.gateway.ts
+++ b/backend/src/user/user.gateway.ts
@@ -1,25 +1,14 @@
-import { SocketId } from './../util/type';
-import { UserInfoDto } from './dto/user-info.dto';
 import { Server } from 'socket.io';
-import {
-  SubscribeMessage,
-  WebSocketGateway,
-  WebSocketServer,
-} from '@nestjs/websockets';
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 
-import { Activity, UserId } from '../util/type';
-import { ActivityManager } from '../user-status/activity.manager';
-import { UserRelationshipStorage } from '../user-status/user-relationship.storage';
+import { SocketId } from '../util/type';
+import { UserId } from '../util/type';
+import { UserInfoDto } from './dto/user.dto';
 
 @WebSocketGateway()
 export class UserGateway {
   @WebSocketServer()
   private server: Server;
-
-  constructor(
-    private activityManager: ActivityManager,
-    private userRelationshipStorage: UserRelationshipStorage,
-  ) {}
 
   /*****************************************************************************
    *                                                                           *
@@ -30,12 +19,11 @@ export class UserGateway {
   /**
    * @description activity & relationship 정보 전달
    *
-   * @param requesterId 요청한 유저의 id
-   * @param requestedId 요청받은 유저의 id
+   * @param socketId 요청한 유저의 socket id
+   * @param userInfo 요청한 유저의 activity & relationship 정보
    */
-  @SubscribeMessage('message')
-  emitUserInfo(socketId: SocketId, userInfoDto: UserInfoDto) {
-    this.server.to(socketId).emit('userInfo', userInfoDto);
+  emitUserInfo(socketId: SocketId, userInfo: UserInfoDto) {
+    this.server.to(socketId).emit('userInfo', userInfo);
   }
 
   /*****************************************************************************
@@ -43,4 +31,81 @@ export class UserGateway {
    * SECTION : Friends                                                         *
    *                                                                           *
    ****************************************************************************/
+
+  /**
+   * @description 친구 요청 수락 시 요청한 유저에게 어떤 유저와 친구가 됐는지 알림
+   *
+   * @param senderSocketId 요청한 유저의 socket id
+   * @param newFriendId 요청을 수락한 유저의 id
+   */
+  emitFriendAccepted(senderSocketId: SocketId, newFriendId: UserId) {
+    this.server.to(senderSocketId).emit('friendAccepted', { newFriendId });
+  }
+
+  /**
+   * @description 친구 요청 거절 시 요청한 유저에게 어떤 유저가 요청을 거절했는지 알림
+   *
+   * @param senderSocketId 요청한 유저의 socket id
+   * @param declinedBy 요청을 거절한 유저의 id
+   */
+  emitFriendDeclined(senderSocketId: SocketId, declinedBy: UserId) {
+    this.server.to(senderSocketId).emit('friendDeclined', { declinedBy });
+  }
+
+  /**
+   * @description 친구 요청 취소 시 취소 당한 유저에게 어떤 유저가 요청을 취소했는지 알림
+   *
+   * @param receiverSocketId 취소 당한 유저의 socket id
+   * @param cancelledBy 요청을 취소한 유저의 id
+   */
+  emitFriendCancelled(receiverSocketId: SocketId, cancelledBy: UserId) {
+    this.server.to(receiverSocketId).emit('friendCancelled', { cancelledBy });
+  }
+
+  /**
+   * @description 친구 요청이 왔을 때 요청 받은 유저에게 알림
+   *
+   * @param receiverSocketId 요청 받은 유저의 socket id
+   */
+  emitPendingFriendRequest(receiverSocketId: SocketId, isPending: boolean) {
+    this.server
+      .to(receiverSocketId)
+      .emit('pendingFriendRequest', { isPending });
+  }
+
+  /**
+   * @description 친구가 삭제되었을 때 삭제된 유저에게 알림
+   *
+   * @param removedSocketId 삭제된 유저의 socket id
+   * @param removedBy 삭제한 유저의 id
+   */
+  emitFriendRemoved(removedSocketId: SocketId, removedBy: UserId) {
+    this.server.to(removedSocketId).emit('friendRemoved', { removedBy });
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Block / unblock                                                 *
+   *                                                                           *
+   ****************************************************************************/
+
+  /**
+   * @description 유저가 차단되었을 때 차단당한 유저에게 누구에게 차단 됐는지 알림
+   *
+   * @param blockedSocketId 차단당한 유저의 socket id
+   * @param blockedBy 차단한 유저의 id
+   */
+  emitBlocked(blockedSocketId: SocketId, blockedBy: UserId) {
+    this.server.to(blockedSocketId).emit('blocked', { blockedBy });
+  }
+
+  /**
+   * @description 유저가 차단 해제되었을 때 차단 해제된 유저에게 누구에게 차단 해제 됐는지 알림
+   *
+   * @param unblockedSocketId 차단 해제된 유저의 socket id
+   * @param unblockedBy 차단 해제한 유저의 id
+   */
+  emitUnblocked(unblockedSocketId: SocketId, unblockedBy: UserId) {
+    this.server.to(unblockedSocketId).emit('unblocked', { unblockedBy });
+  }
 }

--- a/backend/src/user/user.gateway.ts
+++ b/backend/src/user/user.gateway.ts
@@ -1,3 +1,5 @@
+import { SocketId } from './../util/type';
+import { UserInfoDto } from './dto/user-info.dto';
 import { Server } from 'socket.io';
 import {
   SubscribeMessage,
@@ -19,6 +21,12 @@ export class UserGateway {
     private userRelationshipStorage: UserRelationshipStorage,
   ) {}
 
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : User info                                                       *
+   *                                                                           *
+   ****************************************************************************/
+
   /**
    * @description activity & relationship 정보 전달
    *
@@ -26,25 +34,13 @@ export class UserGateway {
    * @param requestedId 요청받은 유저의 id
    */
   @SubscribeMessage('message')
-  emitUserInfo(requesterId: UserId, requestedId: UserId) {
-    let activity: Activity = 'offline';
-    const currentUi = this.activityManager.getActivity(requestedId);
-    if (currentUi) {
-      activity = currentUi === 'playingGame' ? 'inGame' : 'online';
-    }
-
-    // TODO : 게임 중이라면 GameStorage 에서 gameId 가져오기
-    const gameId = null;
-
-    const relationship =
-      this.userRelationshipStorage.getRelationship(requesterId, requestedId) ??
-      'normal';
-
-    this.server.emit('userInfo', {
-      activity,
-      gameId,
-      relationship,
-      userId: requestedId,
-    });
+  emitUserInfo(socketId: SocketId, userInfoDto: UserInfoDto) {
+    this.server.to(socketId).emit('userInfo', userInfoDto);
   }
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Friends                                                         *
+   *                                                                           *
+   ****************************************************************************/
 }

--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -39,10 +39,3 @@ export type CurrentUi =
   | 'waitingRoom';
 
 export type Activity = 'online' | 'offline' | 'inGame';
-
-export interface UserInfoMessage {
-  activity: Activity;
-  gameId: number;
-  relationship: Relationship;
-  userId: UserId;
-}


### PR DESCRIPTION
## 개요
- #65 완성

## 작업 사항
- 아래 이벤트들 emitter 생성.
  - 친구 요청 수락 (`friendAccepted`)
  - 친구 요청 거절 (`friendDecliend`)
  - 친구 요청 취소 (`friendCancelled`)
  - 친구 요청 수신 여부 확인 (`pendingFriendRequest`)
  - 친구 삭제 (`friendRemoved`)
  - 차단 (`blocked`)
  - 차단 해제 (`unblocked`)
- [`friendRemoved`](https://www.notion.so/WebSocket-API-d8355825129b4b2e9f6fc83fdf5e1c7b#73d46fc97fb3442bb1343abbc0fb8456), [`blocked`](https://www.notion.so/WebSocket-API-d8355825129b4b2e9f6fc83fdf5e1c7b#be362c45f32740e8afbe87904f227c14), [`unblocked`](https://www.notion.so/WebSocket-API-d8355825129b4b2e9f6fc83fdf5e1c7b#1b56371b2c004bce99067dc1e2fddfb2) 이벤트들은 설계에 누락 돼있어 설계에도 추가했습니다.

## 변경점
- `emitUserInfo` method 에서 DTO 데이터 추리는 과정을 UserService 의 역할이라고 판단해 분리하고, 테스트에 반영했습니다.

close #65 
