### PR TITLE
✨ feat : /chats 로 오는 요청을 처리하는 ChatsController 구현 #87

### DIFF
--- a/backend/src/chats/chats.controller.ts
+++ b/backend/src/chats/chats.controller.ts
@@ -1,0 +1,143 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  ParseArrayPipe,
+  ParseIntPipe,
+  Post,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+
+import { ChatsService } from './chats.service';
+import {
+  ControlMessageDto,
+  CreateChannelDto,
+  JoinChannelDto,
+} from './dto/chats.dto';
+import { MockAuthGuard } from './mock-auth/mock-auth.guard';
+import { Response } from 'express';
+import { VerifiedRequest } from '../util/type';
+
+@UseGuards(MockAuthGuard)
+@Controller('chats')
+export class ChatsController {
+  constructor(private readonly chatsService: ChatsService) {}
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : chats                                                           *
+   *                                                                           *
+   ****************************************************************************/
+
+  @Get()
+  findAllChannels(@Req() req: VerifiedRequest) {
+    return this.chatsService.findAllChannels(req.user.userId);
+  }
+
+  @Post()
+  async createChannel(
+    @Req() req: VerifiedRequest,
+    @Body() createChannelDto: CreateChannelDto,
+    @Res() res: Response,
+  ) {
+    res
+      .set(
+        'location',
+        `/chats/${await this.chatsService.createChannel(
+          req.user.userId,
+          createChannelDto,
+        )}`,
+      )
+      .status(HttpStatus.CREATED)
+      .end();
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Join & Leave channel                                            *
+   *                                                                           *
+   ****************************************************************************/
+
+  @Get(':channelId')
+  findChannelMembers(
+    @Req() req: VerifiedRequest,
+    @Param('channelId', ParseIntPipe) channelId: number,
+  ) {
+    return this.chatsService.findChannelMembers(channelId, req.user.userId);
+  }
+
+  @Post(':channelId/user/:userId')
+  joinChannel(
+    @Req() req: VerifiedRequest,
+    @Param('channelId', ParseIntPipe) channelId: number,
+    @Param('userId', ParseIntPipe) userId: number,
+    @Body() joinChannelDto: JoinChannelDto,
+  ) {
+    return this.chatsService.joinChannel(
+      channelId,
+      req.user.userId,
+      userId !== req.user.userId,
+      joinChannelDto.password || null,
+    );
+  }
+
+  @Delete(':channelId/user')
+  leaveChannel(
+    @Req() req: VerifiedRequest,
+    @Param('channelId', ParseIntPipe) channelId: number,
+  ) {
+    return this.chatsService.leaveChannel(channelId, req.user.userId);
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Messages                                                        *
+   *                                                                           *
+   ****************************************************************************/
+
+  @Get(':channelId/message')
+  findChannelMessages(
+    @Req() req: VerifiedRequest,
+    @Param('channelId', ParseIntPipe) channelId: number,
+    @Query('range', new ParseArrayPipe({ items: Number, separator: ',' }))
+    query: Array<number>,
+  ) {
+    // FIXME : array size of range should be 2
+    // FIXME : range validation, move to pipe or ... somewhere
+    const MAX_MESSAGE = 10000;
+    if (
+      query.length !== 2 ||
+      query[0] < 0 ||
+      query[0] > MAX_MESSAGE ||
+      query[1] > MAX_MESSAGE
+    ) {
+      throw new BadRequestException('Invalid range query');
+    }
+    return this.chatsService.findChannelMessages(
+      channelId,
+      req.user.userId,
+      query[0],
+      query[1],
+    );
+  }
+
+  @Post(':channelId/message')
+  controlMessage(
+    @Req() req: VerifiedRequest,
+    @Param('channelId', ParseIntPipe) channelId: number,
+    @Body() controlMessageDto: ControlMessageDto,
+  ) {
+    return this.chatsService.controlMessage(
+      channelId,
+      req.user.userId,
+      controlMessageDto.message,
+    );
+  }
+}

--- a/backend/src/chats/chats.module.ts
+++ b/backend/src/chats/chats.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Channels } from '../entity/channels.entity';
+import { ChatsController } from './chats.controller';
 import { ChatsGateway } from './chats.gateway';
 import { ChatsService } from './chats.service';
 import { Messages } from '../entity/messages.entity';
@@ -11,5 +12,6 @@ import { UserStatusModule } from '../user-status/user-status.module';
   imports: [TypeOrmModule.forFeature([Channels, Messages]), UserStatusModule],
   providers: [ChatsGateway, ChatsService],
   exports: [ChatsGateway],
+  controllers: [ChatsController],
 })
 export class ChatsModule {}

--- a/backend/src/chats/chats.service.spec.ts
+++ b/backend/src/chats/chats.service.spec.ts
@@ -683,7 +683,7 @@ describe('ChatsService', () => {
 
       await service.joinChannel(newChannelId, anotherUserId, true);
       const msg = { message: 'hello message!' };
-      await service.manageMessage(newChannelId, userId, msg.message);
+      await service.controlMessage(newChannelId, userId, msg.message);
       expect(newMessageSpy).toBeCalledWith(
         userId,
         newChannelId,
@@ -733,7 +733,11 @@ describe('ChatsService', () => {
       );
       expect(
         async () =>
-          await service.manageMessage(newChannelId, anotherUserId, msg.message),
+          await service.controlMessage(
+            newChannelId,
+            anotherUserId,
+            msg.message,
+          ),
       ).rejects.toThrow(ForbiddenException);
     });
 
@@ -748,7 +752,7 @@ describe('ChatsService', () => {
 
       await service.joinChannel(newChannelId, anotherUserId, true);
       let msg = { message: `/role ${anotherUserId} admin` };
-      await service.manageMessage(newChannelId, ownerId, msg.message);
+      await service.controlMessage(newChannelId, ownerId, msg.message);
       expect(channelStorage.getUserRole(newChannelId, anotherUserId)).toBe(
         'admin',
       );
@@ -758,7 +762,7 @@ describe('ChatsService', () => {
         'admin',
       );
       msg = { message: `/role ${anotherUserId} member` };
-      await service.manageMessage(newChannelId, ownerId, msg.message);
+      await service.controlMessage(newChannelId, ownerId, msg.message);
       expect(channelStorage.getUserRole(newChannelId, anotherUserId)).toBe(
         'member',
       );
@@ -783,12 +787,12 @@ describe('ChatsService', () => {
       await service.joinChannel(newChannelId, memberId, true);
 
       let msg = { message: `/role ${adminId} admin` };
-      await service.manageMessage(newChannelId, ownerId, msg.message);
+      await service.controlMessage(newChannelId, ownerId, msg.message);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
       expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
 
       msg = { message: `/role ${memberId} admin` };
-      await service.manageMessage(newChannelId, adminId, msg.message);
+      await service.controlMessage(newChannelId, adminId, msg.message);
       expect(channelStorage.getUserRole(newChannelId, memberId)).toBe('admin');
       expect(roleChangedSpy).toBeCalledWith(memberId, newChannelId, 'admin');
     });
@@ -807,26 +811,26 @@ describe('ChatsService', () => {
       await service.joinChannel(newChannelId, memberId, true);
 
       let msg = { message: `/role ${adminId} admin` };
-      await service.manageMessage(newChannelId, ownerId, msg.message);
+      await service.controlMessage(newChannelId, ownerId, msg.message);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
       expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
 
       msg = { message: `/role ${adminId} member` };
       expect(
         async () =>
-          await service.manageMessage(newChannelId, memberId, msg.message),
+          await service.controlMessage(newChannelId, memberId, msg.message),
       ).rejects.toThrow(ForbiddenException);
 
       msg = { message: `/role ${adminId} owner` };
       expect(
         async () =>
-          await service.manageMessage(newChannelId, memberId, msg.message),
+          await service.controlMessage(newChannelId, memberId, msg.message),
       ).rejects.toThrow(BadRequestException);
 
       msg = { message: `/role ${ownerId} admin` };
       expect(
         async () =>
-          await service.manageMessage(newChannelId, memberId, msg.message),
+          await service.controlMessage(newChannelId, memberId, msg.message),
       ).rejects.toThrow(ForbiddenException);
     });
 
@@ -842,7 +846,11 @@ describe('ChatsService', () => {
       const msg = { message: `/role ${ownerId} admin` };
       expect(
         async () =>
-          await service.manageMessage(newChannelId, anotherUserId, msg.message),
+          await service.controlMessage(
+            newChannelId,
+            anotherUserId,
+            msg.message,
+          ),
       ).rejects.toThrow(ForbiddenException);
     });
 
@@ -858,12 +866,20 @@ describe('ChatsService', () => {
       let msg = { message: `/role ${ownerId} admin` };
       expect(
         async () =>
-          await service.manageMessage(newChannelId, anotherUserId, msg.message),
+          await service.controlMessage(
+            newChannelId,
+            anotherUserId,
+            msg.message,
+          ),
       ).rejects.toThrow(ForbiddenException);
       msg = { message: `/ban ${ownerId} 42` };
       expect(
         async () =>
-          await service.manageMessage(newChannelId, anotherUserId, msg.message),
+          await service.controlMessage(
+            newChannelId,
+            anotherUserId,
+            msg.message,
+          ),
       ).rejects.toThrow(ForbiddenException);
     });
 
@@ -881,12 +897,12 @@ describe('ChatsService', () => {
       await service.joinChannel(newChannelId, memberId, true);
 
       let msg = { message: `/role ${adminId} admin` };
-      await service.manageMessage(newChannelId, ownerId, msg.message);
+      await service.controlMessage(newChannelId, ownerId, msg.message);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
       expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
 
       msg = { message: `/mute ${memberId} 5` };
-      await service.manageMessage(newChannelId, ownerId, msg.message);
+      await service.controlMessage(newChannelId, ownerId, msg.message);
       expect(
         Math.round(
           DateTime.now()
@@ -919,14 +935,14 @@ describe('ChatsService', () => {
       await service.joinChannel(newChannelId, memberId, true);
 
       let msg = { message: `/role ${adminId} admin` };
-      await service.manageMessage(newChannelId, ownerId, msg.message);
+      await service.controlMessage(newChannelId, ownerId, msg.message);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
       expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
 
       msg = { message: `/mute ${memberId} -5` };
       expect(
         async () =>
-          await service.manageMessage(newChannelId, ownerId, msg.message),
+          await service.controlMessage(newChannelId, ownerId, msg.message),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -944,14 +960,14 @@ describe('ChatsService', () => {
       await service.joinChannel(newChannelId, memberId, true);
 
       let msg = { message: `/role ${adminId} admin` };
-      await service.manageMessage(newChannelId, ownerId, msg.message);
+      await service.controlMessage(newChannelId, ownerId, msg.message);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
       expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
 
       msg = { message: `/mute ${ownerId} 5` };
       expect(
         async () =>
-          await service.manageMessage(newChannelId, adminId, msg.message),
+          await service.controlMessage(newChannelId, adminId, msg.message),
       ).rejects.toThrow(ForbiddenException);
     });
 
@@ -969,12 +985,12 @@ describe('ChatsService', () => {
       await service.joinChannel(newChannelId, memberId, true);
 
       let msg = { message: `/role ${adminId} admin` };
-      await service.manageMessage(newChannelId, ownerId, msg.message);
+      await service.controlMessage(newChannelId, ownerId, msg.message);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
       expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
 
       msg = { message: `/ban ${memberId} 5` };
-      await service.manageMessage(newChannelId, adminId, msg.message);
+      await service.controlMessage(newChannelId, adminId, msg.message);
       expect(
         Math.round(
           DateTime.now()
@@ -1007,7 +1023,7 @@ describe('ChatsService', () => {
       const msg = { message: `/ba ${adminId} admin` };
       expect(
         async () =>
-          await service.manageMessage(newChannelId, ownerId, msg.message),
+          await service.controlMessage(newChannelId, ownerId, msg.message),
       ).rejects.toThrow(BadRequestException);
     });
   });

--- a/backend/src/chats/dto/chats.dto.ts
+++ b/backend/src/chats/dto/chats.dto.ts
@@ -1,4 +1,10 @@
-import { IsOptional, IsString, Length, Matches } from 'class-validator';
+import {
+  IsOptional,
+  IsString,
+  IsStrongPassword,
+  Length,
+  Matches,
+} from 'class-validator';
 
 import { ChannelId, UserRole } from '../../util/type';
 
@@ -37,11 +43,43 @@ export class CreateChannelDto {
 
   // TODO : password max length 정하기
   @IsString()
-  @Length(1, 20)
+  @Length(8, 20)
   @IsOptional()
+  @IsStrongPassword({
+    minLowercase: 1,
+    minUppercase: 0,
+    minNumbers: 1,
+    minSymbols: 0,
+  })
   password?: string;
 
   @IsString()
   @Matches(/^(public|protected|private)$/)
   accessMode: 'public' | 'protected' | 'private';
 }
+
+export class ControlMessageDto {
+  @IsString()
+  @Length(1, 4096)
+  message: string;
+}
+
+export class JoinChannelDto {
+  @IsString()
+  @Length(8, 20)
+  @IsOptional()
+  @IsStrongPassword({
+    minLowercase: 1,
+    minUppercase: 0,
+    minNumbers: 1,
+    minSymbols: 0,
+  })
+  password: string;
+}
+
+// TODO: range validation
+// export class FindChannelMessageQueryDto {
+//   @IsArray({ each: true })
+//   @Length(2, 2)
+//   range: number[];
+// }

--- a/backend/src/chats/mock-auth/mock-auth.guard.ts
+++ b/backend/src/chats/mock-auth/mock-auth.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MockAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    const userId = req.headers['x-user-id'];
+    if (!userId || isNaN(userId)) {
+      return false;
+    }
+    req.user = { userId: Number(userId) };
+    return true;
+  }
+}

--- a/backend/test/chats.e2e-spec.ts
+++ b/backend/test/chats.e2e-spec.ts
@@ -1,0 +1,558 @@
+import { DataSource } from 'typeorm';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { faker } from '@faker-js/faker';
+import * as request from 'supertest';
+
+import { AppModule } from '../src/app.module';
+import { BannedMembers } from '../src/entity/banned-members.entity';
+import { BlockedUsers } from '../src/entity/blocked-users.entity';
+import { ChannelMembers } from '../src/entity/channel-members.entity';
+import { ChannelStorage } from '../src/user-status/channel.storage';
+import { Channels } from '../src/entity/channels.entity';
+import { Friends } from '../src/entity/friends.entity';
+import { Messages } from '../src/entity/messages.entity';
+import { UserRelationshipStorage } from '../src/user-status/user-relationship.storage';
+import { Users } from '../src/entity/users.entity';
+import {
+  TYPEORM_SHARED_CONFIG,
+  createDataSources,
+  destroyDataSources,
+} from './db-resource-manager';
+import {
+  generateUsers,
+  generateChannels,
+  generateChannelMembers,
+  generateMessages,
+} from './generate-mock-data';
+
+process.env.NODE_ENV = 'development';
+
+const TEST_DB = 'test_db_chats_e2e';
+const ENTITIES = [
+  BannedMembers,
+  BlockedUsers,
+  ChannelMembers,
+  Channels,
+  Friends,
+  Messages,
+  Users,
+];
+
+describe('UserController (e2e)', () => {
+  let app: INestApplication;
+  let initDataSource: DataSource;
+  let dataSource: DataSource;
+  let usersEntities: Users[];
+  let channelsEntities: Channels[];
+  let channelMembersEntities: ChannelMembers[];
+
+  beforeAll(async () => {
+    const dataSources = await createDataSources(TEST_DB, ENTITIES);
+    initDataSource = dataSources.initDataSource;
+    dataSource = dataSources.dataSource;
+    usersEntities = generateUsers(20);
+    channelsEntities = generateChannels(usersEntities);
+    await dataSource.getRepository(Users).save(usersEntities);
+    await dataSource.getRepository(Channels).save(channelsEntities);
+    channelsEntities = await dataSource.getRepository(Channels).find();
+    channelMembersEntities = generateChannelMembers(
+      usersEntities,
+      channelsEntities,
+    );
+    await dataSource.getRepository(ChannelMembers).save(channelMembersEntities);
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          ...TYPEORM_SHARED_CONFIG,
+          autoLoadEntities: true,
+          database: TEST_DB,
+        }),
+        AppModule,
+      ],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        forbidNonWhitelisted: true,
+        transform: true,
+        whitelist: true,
+      }),
+    );
+    await app.init();
+    await app.listen(4250);
+    for (const user of usersEntities) {
+      await app.get(UserRelationshipStorage).load(user.userId);
+      await app.get(ChannelStorage).loadUser(user.userId);
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await destroyDataSources(TEST_DB, dataSource, initDataSource);
+  });
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : REST API                                                        *
+   *                                                                           *
+   ****************************************************************************/
+  describe('/chats', () => {
+    it('GET /chats with valid userId', async () => {
+      return request(app.getHttpServer())
+        .get('/chats')
+        .set('x-user-id', usersEntities[0].userId.toString())
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toEqual({
+            joinedChannels: expect.any(Array),
+            otherChannels: expect.any(Array),
+          });
+        });
+    });
+
+    it('GET /chats with invalid userId', async () => {
+      return request(app.getHttpServer())
+        .get('/chats')
+        .set('x-user-id', '4242')
+        .expect(400);
+    });
+
+    it('POST /chats (valid DTO without password)', async () => {
+      return request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', usersEntities[0].userId.toString())
+        .send({ channelName: 'new channel', accessMode: 'public' })
+        .expect(201)
+        .expect((res) => {
+          expect(res.headers['location']).toMatch(/\/chats\/\d+/);
+        });
+    });
+
+    it('POST /chats (valid DTO with password)', async () => {
+      return request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', usersEntities[0].userId.toString())
+        .send({
+          channelName: 'new channel',
+          password: '1q2w3e4r',
+          accessMode: 'protected',
+        })
+        .expect(201)
+        .expect((res) => {
+          expect(res.headers['location']).toMatch(/\/chats\/\d+/);
+        });
+    });
+
+    it('POST /chats (invalid DTO with empty channelName)', async () => {
+      return request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', usersEntities[0].userId.toString())
+        .send({ channelName: '', accessMode: 'public' })
+        .expect(400);
+    });
+
+    it('POST /chats (invalid DTO with unexpected accessMode)', async () => {
+      return request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', usersEntities[0].userId.toString())
+        .send({ channelName: '400', accessMode: 'PUblic' })
+        .expect(400);
+    });
+
+    it('POST /chats (invalid DTO with unexpected password)', async () => {
+      return request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', usersEntities[0].userId.toString())
+        .send({
+          channelName: '400',
+          password: 'doNotNeeded',
+          accessMode: 'public',
+        })
+        .expect(400);
+    });
+
+    it('POST /chats (invalid DTO with too long password)', async () => {
+      return request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', usersEntities[0].userId.toString())
+        .send({
+          channelName: '400',
+          password: 'ThisIsReallyLongPWD21', // 21 characters
+          accessMode: 'protected',
+        })
+        .expect(400);
+    });
+
+    it('POST /chats (invalid DTO with Unicode password)', async () => {
+      return request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', usersEntities[0].userId.toString())
+        .send({
+          channelName: '400',
+          password: '왜이러는걸까요',
+          accessMode: 'protected',
+        })
+        .expect(400);
+    });
+  });
+
+  describe('/chats/:channelId, Join & Leave channel', () => {
+    it('GET /chats/:channelId with existing channelId (not DM)', async () => {
+      const channel = channelsEntities.find((c) => c.dmPeerId === null);
+      return request(app.getHttpServer())
+        .get(`/chats/${channel.channelId}`)
+        .set('x-user-id', channel.ownerId.toString())
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toMatchObject({
+            channelMembers: expect.any(Array),
+            isReadonlyDm: null,
+          });
+        });
+    });
+
+    it('GET /chats/:channelId with existing channelId (DM)', async () => {
+      const channel = channelsEntities.find((c) => c.dmPeerId !== null);
+      return request(app.getHttpServer())
+        .get(`/chats/${channel.channelId}`)
+        .set('x-user-id', channel.ownerId.toString())
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toMatchObject({
+            channelMembers: expect.any(Array),
+            isReadonlyDm: expect.any(Boolean),
+          });
+        });
+    });
+
+    it('GET /chats/:channelId with non-member userId', async () => {
+      const channel = channelsEntities.find((c) => c.dmPeerId === null);
+      const channelMemberIds = channelMembersEntities
+        .filter((c) => {
+          return c.channelId === channel.channelId;
+        })
+        .map((v) => v.memberId);
+      const nonChannelMember = usersEntities.find(
+        (u) => !channelMemberIds.includes(u.userId),
+      );
+      if (nonChannelMember === undefined) {
+        return console.log(
+          'GET /chats/:channelId with non-member userId TEST SKIPPED!!!',
+        );
+      }
+      const nonChannelMemberId = nonChannelMember.userId;
+      return request(app.getHttpServer())
+        .get(`/chats/${channel.channelId}`)
+        .set('x-user-id', nonChannelMemberId.toString())
+        .expect(403);
+    });
+
+    it('GET /chats/:channelId with non-existing channelId', async () => {
+      return request(app.getHttpServer())
+        .get(`/chats/42424242`)
+        .set('x-user-id', usersEntities[0].userId.toString())
+        .expect(404);
+    });
+
+    it('POST /chats/:channelId/user/:userId (invited, public)', async () => {
+      let newChannelId: string;
+      const newChannelOwner = usersEntities[2];
+      await request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .send({
+          channelName: 'test',
+          accessMode: 'public',
+        })
+        .expect(201)
+        .expect(async (res) => {
+          newChannelId = res.headers['location'].replace('/chats/', '');
+        });
+
+      const newChannelMember = usersEntities[3];
+
+      return request(app.getHttpServer())
+        .post(`/chats/${newChannelId}/user/${newChannelMember.userId}`)
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .expect(201);
+    });
+
+    it('POST /chats/:channelId/user/:userId (not invited, protected)', async () => {
+      let newChannelId: string;
+      const newChannelOwner = usersEntities[2];
+      await request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .send({
+          channelName: 'test',
+          accessMode: 'protected',
+          password: 'abc1234!',
+        })
+        .expect(201)
+        .expect(async (res) => {
+          newChannelId = res.headers['location'].replace('/chats/', '');
+        });
+
+      const newChannelMember = usersEntities[3];
+
+      return request(app.getHttpServer())
+        .post(`/chats/${newChannelId}/user/${newChannelMember.userId}`)
+        .set('x-user-id', newChannelMember.userId.toString())
+        .send({ password: 'abc1234!' })
+        .expect(201);
+    });
+
+    it('POST /chats/:channelId/user/:userId (not invited, incorrect password)', async () => {
+      let newChannelId: string;
+      const newChannelOwner = usersEntities[2];
+      await request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .send({
+          channelName: 'test',
+          accessMode: 'protected',
+          password: 'abc1234!',
+        })
+        .expect(201)
+        .expect(async (res) => {
+          newChannelId = res.headers['location'].replace('/chats/', '');
+        });
+
+      const newChannelMember = usersEntities[3];
+
+      return request(app.getHttpServer())
+        .post(`/chats/${newChannelId}/user/${newChannelMember.userId}`)
+        .set('x-user-id', newChannelMember.userId.toString())
+        .send({ password: 'Abc1234!' })
+        .expect(403);
+    });
+
+    it('POST /chats/:channelId/user/:userId (invited, protected)', async () => {
+      let newChannelId: string;
+      const newChannelOwner = usersEntities[2];
+      await request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .send({
+          channelName: 'test',
+          accessMode: 'protected',
+          password: 'abc1234!',
+        })
+        .expect(201)
+        .expect(async (res) => {
+          newChannelId = res.headers['location'].replace('/chats/', '');
+        });
+
+      const newChannelMember = usersEntities[3];
+
+      return request(app.getHttpServer())
+        .post(`/chats/${newChannelId}/user/${newChannelMember.userId}`)
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .expect(201);
+    });
+
+    it('POST /chats/:channelId/user/:userId (invited, private)', async () => {
+      let newChannelId: string;
+      const newChannelOwner = usersEntities[2];
+      await request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .send({
+          channelName: 'test',
+          accessMode: 'private',
+        })
+        .expect(201)
+        .expect(async (res) => {
+          newChannelId = res.headers['location'].replace('/chats/', '');
+        });
+
+      const newChannelMember = usersEntities[3];
+
+      return request(app.getHttpServer())
+        .post(`/chats/${newChannelId}/user/${newChannelMember.userId}`)
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .expect(201);
+    });
+
+    it('POST /chats/:channelId/user/:userId (not invited, private)', async () => {
+      let newChannelId: string;
+      const newChannelOwner = usersEntities[2];
+      await request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .send({
+          channelName: 'test',
+          accessMode: 'private',
+        })
+        .expect(201)
+        .expect(async (res) => {
+          newChannelId = res.headers['location'].replace('/chats/', '');
+        });
+
+      const newChannelMember = usersEntities[3];
+
+      return request(app.getHttpServer())
+        .post(`/chats/${newChannelId}/user/${newChannelMember.userId}`)
+        .set('x-user-id', newChannelMember.userId.toString())
+        .expect(403);
+    });
+
+    it('DELETE /chats/:channelId/user (owner)', async () => {
+      let newChannelId: string;
+      const newChannelOwner = usersEntities[2];
+      await request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .send({
+          channelName: 'test',
+          accessMode: 'public',
+        })
+        .expect(201)
+        .expect(async (res) => {
+          newChannelId = res.headers['location'].replace('/chats/', '');
+        });
+      return request(app.getHttpServer())
+        .delete(`/chats/${newChannelId}/user`)
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .expect(200);
+    });
+
+    it('DELETE /chats/:channelId/user (not owner)', async () => {
+      let newChannelId: string;
+      const newChannelOwner = usersEntities[2];
+      await request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .send({
+          channelName: 'test',
+          accessMode: 'public',
+        })
+        .expect(201)
+        .expect(async (res) => {
+          newChannelId = res.headers['location'].replace('/chats/', '');
+        });
+
+      const newChannelMember = usersEntities[3];
+      await request(app.getHttpServer())
+        .post(`/chats/${newChannelId}/user/${newChannelMember.userId}`)
+        .set('x-user-id', newChannelMember.userId.toString())
+        .expect(201);
+      return request(app.getHttpServer())
+        .delete(`/chats/${newChannelId}/user`)
+        .set('x-user-id', newChannelMember.userId.toString())
+        .expect(200);
+    });
+
+    it('DELETE /chats/:channelId/user (not channel member)', async () => {
+      let newChannelId: string;
+      const newChannelOwner = usersEntities[2];
+      await request(app.getHttpServer())
+        .post('/chats')
+        .set('x-user-id', newChannelOwner.userId.toString())
+        .send({
+          channelName: 'test',
+          accessMode: 'public',
+        })
+        .expect(201)
+        .expect(async (res) => {
+          newChannelId = res.headers['location'].replace('/chats/', '');
+        });
+
+      const newChannelMember = usersEntities[3];
+      return request(app.getHttpServer())
+        .delete(`/chats/${newChannelId}/user`)
+        .set('x-user-id', newChannelMember.userId.toString())
+        .expect(403);
+    });
+  });
+
+  describe('/chats/:channelId, Messages', () => {
+    it('GET /chats/:channelId/message?range=2,10 ', async () => {
+      const channel = channelsEntities.find((c) => c.dmPeerId !== null);
+      const messages = generateMessages(
+        channelMembersEntities.filter((c) => c.channelId === channel.channelId),
+      );
+      const [offset, size] = [2, 10];
+      await dataSource.getRepository(Messages).insert(messages);
+      return request(app.getHttpServer())
+        .get(`/chats/${channel.channelId}/message`)
+        .query({ range: `${offset},${size}` })
+        .set('x-user-id', channel.ownerId.toString())
+        .expect(200)
+        .expect(async (res) => {
+          const resLength = res.body.messages.length;
+          resLength < size
+            ? expect(resLength).toBe(messages.length - offset)
+            : expect(resLength).toBe(size);
+          expect(res.body.messages.length).toBeLessThanOrEqual(42);
+          await dataSource.getRepository(Messages).remove(messages);
+        });
+    });
+
+    it('GET /chats/:channelId/message?range=-4,2 (invalid) ', async () => {
+      const channel = channelsEntities.find((c) => c.dmPeerId !== null);
+      const messages = generateMessages(
+        channelMembersEntities.filter((c) => c.channelId === channel.channelId),
+      );
+      const [offset, size] = [-4, 2];
+      await dataSource.getRepository(Messages).insert(messages);
+      return request(app.getHttpServer())
+        .get(`/chats/${channel.channelId}/message`)
+        .query({ range: `${offset},${size}` })
+        .set('x-user-id', channel.ownerId.toString())
+        .expect(400);
+    });
+
+    it('GET /chats/:channelId/message?range=0,MAX_MESSAGE + 1 (invalid) ', async () => {
+      const channel = channelsEntities.find((c) => c.dmPeerId !== null);
+      const messages = generateMessages(
+        channelMembersEntities.filter((c) => c.channelId === channel.channelId),
+      );
+      const MAX_MESSAGE = 10000;
+      const [offset, size] = [0, MAX_MESSAGE + 1];
+      await dataSource.getRepository(Messages).insert(messages);
+      return request(app.getHttpServer())
+        .get(`/chats/${channel.channelId}/message`)
+        .query({ range: `${offset},${size}` })
+        .set('x-user-id', channel.ownerId.toString())
+        .expect(400);
+    });
+
+    it('POST /chats/:channelId/message (valid DTO)', async () => {
+      const channel = channelsEntities.find((c) => c.dmPeerId !== null);
+      return request(app.getHttpServer())
+        .post(`/chats/${channel.channelId}/message`)
+        .set('x-user-id', channel.ownerId.toString())
+        .send({
+          message: 'test message',
+        })
+        .expect(201);
+    });
+
+    it('POST /chats/:channelId/message (invalid DTO, empty message)', async () => {
+      const channel = channelsEntities.find((c) => c.dmPeerId !== null);
+      return request(app.getHttpServer())
+        .post(`/chats/${channel.channelId}/message`)
+        .set('x-user-id', channel.ownerId.toString())
+        .send({
+          message: '',
+        })
+        .expect(400);
+    });
+
+    it('POST /chats/:channelId/message (invalid DTO, message too large)', async () => {
+      const channel = channelsEntities.find((c) => c.dmPeerId !== null);
+      return request(app.getHttpServer())
+        .post(`/chats/${channel.channelId}/message`)
+        .set('x-user-id', channel.ownerId.toString())
+        .send({
+          message: faker.datatype.string(4097),
+        })
+        .expect(400);
+    });
+  });
+});


### PR DESCRIPTION
## 개요
- #87 완료
- ChatsService 에 #80 PR 에서 ghan 님이 언급해주신 사항 반영 및 리팩토링

## 작업 사항
- 간략한 Validation 과 함께 `ChatsController` 구현
  - ChatsController 내부의 Validation 및 ChatsService 에서 중복되는 Validation 은 다음 PR 에 pipe 나 guard 로 분리할 계획입니다.
- userId 를 넣어주기 위한 MockAuthGuard 구현
  - 나중에 AuthGuard 가 구현되면 해당 Guard 로 교체할 예정입니다.

---
- #80 PR 에서 채팅방 한글 정렬이 안된다고 언급했는데, string.localeCompare 가 유니코드순 정렬이라서 한글도 잘 정렬된다고 합니다. 숫자 - 알파벳 - 한글 정렬을 위해선 localeCompare 을 사용하면 되고, 숫자 - 한글 - 알파벳 정렬을 하고 싶으면`.sort(new Intl.Collator('ko').compare))` 이런 식으로 하면 된다고 합니다... [참고 링크](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator)
