### PR TITLE
♻️ refactor : 관계 변화 & activity 변화 업데이트

### DIFF
--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -10,10 +10,12 @@ import {
 import { Server, Socket } from 'socket.io';
 import { UsePipes, ValidationPipe } from '@nestjs/common';
 
+import { Activity, UserId } from './../util/type';
 import { ActivityManager } from './activity.manager';
 import { ChannelStorage } from './channel.storage';
 import { ChatsGateway } from '../chats/chats.gateway';
-import { CurrentUiDto } from './dto/current-ui.dto';
+import { CurrentUiDto } from './dto/user-status.dto';
+import { UserActivityDto } from './dto/user-status.dto';
 import { UserRelationshipStorage } from './user-relationship.storage';
 import { UserSocketStorage } from './user-socket.storage';
 
@@ -42,6 +44,11 @@ export class ActivityGateway
    * private gameGateway: GameGateway,
    * private ranksGateway: RanksGateway, */ {}
 
+  /**
+   * @description websocket connection 이 생성될 때 유저 관련 데이터 케싱
+   *
+   * @param clientSocket
+   */
   async handleConnection(clientSocket: Socket) {
     // const accessToken = clientSocket.handshake.headers.cookie
     //   .split(';')
@@ -59,6 +66,11 @@ export class ActivityGateway
     ]);
   }
 
+  /**
+   * @description websocket connection 이 끊길 때 자원 해제 및 타 유저들에게 activity 전달
+   *
+   * @param clientSocket disconnect 되는 유저의 socket
+   */
   handleDisconnect(clientSocket: Socket) {
     const socketId = clientSocket.id;
     const userId = this.userSocketStorage.sockets.get(socketId);
@@ -67,6 +79,7 @@ export class ActivityGateway
     this.userSocketStorage.sockets.delete(socketId);
     this.userRelationshipStorage.unload(userId);
     this.channelStorage.unloadUser(userId);
+    this.emitUserActivity(userId);
   }
 
   // @SubscribeMessage('disconnecting')
@@ -79,6 +92,12 @@ export class ActivityGateway
   //   });
   // }
 
+  /**
+   * @description 유저가 어떤 UI 에 있는지 client 로 부터 받아서 해당 UI 에 맞는 작업 수행
+   *
+   * @param clientSocket 유저의 socket
+   * @param { userId, ui } 유저 아이디, UI 이름
+   */
   @SubscribeMessage('currentUi')
   handleCurrentUi(
     @ConnectedSocket() clientSocket: Socket,
@@ -109,5 +128,44 @@ export class ActivityGateway
     }
     this.activityManager.setActivity(userId, ui);
     // console.log(clientSocket.request.headers);
+  }
+
+  /**
+   * @description activity 정보 전달
+   *
+   * @param requesterSocketId 요청한 유저의 socket id
+   * @param userActivity 요청한 유저의 activity & relationship 정보
+   */
+  emitUserActivity(targetId: UserId) {
+    this.server.emit('userActivity', this.createUserActivityDto(targetId));
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Private Methods                                                 *
+   *                                                                           *
+   ****************************************************************************/
+
+  /**
+   * @description 유저의 상태 정보를 담은 UserActivityDto 를 생성
+   *
+   * @param targetId 조회 대상 유저의 id
+   * @returns
+   */
+  private createUserActivityDto(targetId: UserId): UserActivityDto {
+    let activity: Activity = 'offline';
+    const currentUi = this.activityManager.getActivity(targetId);
+    if (currentUi) {
+      activity = currentUi === 'playingGame' ? 'inGame' : 'online';
+    }
+
+    // TODO : 게임 중이라면 GameStorage 에서 gameId 가져오기
+    const gameId = null;
+
+    return {
+      activity,
+      gameId,
+      userId: targetId,
+    };
   }
 }

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -127,6 +127,9 @@ export class ActivityGateway
       this.chatsGateway.joinRoom(clientSocket.id, room);
     }
     this.activityManager.setActivity(userId, ui);
+    if (!prevActivity) {
+      this.emitUserActivity(userId);
+    }
     // console.log(clientSocket.request.headers);
   }
 

--- a/backend/src/user-status/dto/user-status.dto.ts
+++ b/backend/src/user-status/dto/user-status.dto.ts
@@ -1,7 +1,7 @@
-import { Type } from 'class-transformer';
 import { IsInt, IsString, Matches, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
 
-import { CurrentUi, UserId } from '../../util/type';
+import { Activity, CurrentUi, UserId } from '../../util/type';
 
 export class CurrentUiDto {
   @Type(() => Number)
@@ -19,4 +19,10 @@ export class CurrentUiDto {
     ),
   )
   ui: CurrentUi;
+}
+
+export interface UserActivityDto {
+  activity: Activity;
+  gameId: number;
+  userId: UserId;
 }

--- a/backend/src/user-status/user-status.module.ts
+++ b/backend/src/user-status/user-status.module.ts
@@ -36,6 +36,7 @@ import { Users } from '../entity/users.entity';
     UserSocketStorage,
   ],
   exports: [
+    ActivityGateway,
     ActivityManager,
     ChannelStorage,
     UserRelationshipStorage,

--- a/backend/src/user/dto/user-gateway.dto.ts
+++ b/backend/src/user/dto/user-gateway.dto.ts
@@ -1,10 +1,4 @@
-import { Activity, Relationship, UserId } from '../../util/type';
-
-export interface UserActivityDto {
-  activity: Activity;
-  gameId: number;
-  userId: UserId;
-}
+import { Relationship, UserId } from '../../util/type';
 
 export interface UserRelationshipDto {
   relationship: Relationship | 'normal';

--- a/backend/src/user/dto/user-gateway.dto.ts
+++ b/backend/src/user/dto/user-gateway.dto.ts
@@ -1,36 +1,12 @@
 import { Activity, Relationship, UserId } from '../../util/type';
 
-export interface UserInfoDto {
+export interface UserActivityDto {
   activity: Activity;
   gameId: number;
-  relationship: Relationship | 'normal';
   userId: UserId;
 }
 
-export interface FriendAcceptedDto {
-  newFriendId: UserId;
-}
-
-export interface FriendDeclinedDto {
-  declinedBy: UserId;
-}
-
-export interface FriendCancelledDto {
-  cancelledBy: UserId;
-}
-
-export interface FriendRequestDto {
-  requestedBy: UserId;
-}
-
-export interface FriendRemovedDto {
-  removedBy: UserId;
-}
-
-export interface BlockedDto {
-  blockedBy: UserId;
-}
-
-export interface UnblockedDto {
-  unblockedBy: UserId;
+export interface UserRelationshipDto {
+  relationship: Relationship | 'normal';
+  userId: UserId;
 }

--- a/backend/src/user/guard/accept-friend.guard.ts
+++ b/backend/src/user/guard/accept-friend.guard.ts
@@ -11,21 +11,21 @@ import { RelationshipRequest } from '../../util/type';
 @Injectable()
 export class AcceptFriendGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
-    const { relationship } = context
+    const { relationship, user } = context
       .switchToHttp()
       .getRequest() as RelationshipRequest;
     switch (relationship) {
       case null:
         throw new NotFoundException(
-          'The user had not received a friend request',
+          `The user(${user.userId}) had not received a friend request`,
         );
       case 'blocker':
         throw new BadRequestException(
-          'The user need to unblock the other user first in order to become friends',
+          `The user(${user.userId}) need to unblock the other user first in order to become friends`,
         );
       case 'pendingSender':
         throw new BadRequestException(
-          'The sender of a friend request cannot accept it',
+          `The sender(${user.userId}) of a friend request cannot accept it`,
         );
     }
     return true;

--- a/backend/src/user/guard/blocked-user.guard.ts
+++ b/backend/src/user/guard/blocked-user.guard.ts
@@ -23,7 +23,7 @@ export class BlockedUserGuard implements CanActivate {
     );
     req.relationship = relationship;
     if (relationship === 'blocked') {
-      throw new ForbiddenException('The user is blocked');
+      throw new ForbiddenException(`The user(${req.user.userId}) is blocked`);
     }
     return true;
   }

--- a/backend/src/user/guard/create-friend-request.guard.ts
+++ b/backend/src/user/guard/create-friend-request.guard.ts
@@ -10,18 +10,18 @@ import { RelationshipRequest } from '../../util/type';
 @Injectable()
 export class CreateFriendRequestGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
-    const { relationship } = context
+    const { relationship, user } = context
       .switchToHttp()
       .getRequest() as RelationshipRequest;
 
     if (relationship === 'blocker') {
       throw new BadRequestException(
-        'The user need to unblock the other user first in order to become friends',
+        `The user(${user.userId}) must unblock the other user first in order to become friends`,
       );
     }
     if (relationship === 'friend' || relationship === 'pendingReceiver') {
       throw new BadRequestException(
-        'The user had already received a friend request from or been friends with the other user',
+        `The user(${user.userId}) had already received a friend request from or been friends with the other user`,
       );
     }
     return true;

--- a/backend/src/user/guard/delete-block.guard.ts
+++ b/backend/src/user/guard/delete-block.guard.ts
@@ -10,11 +10,13 @@ import { RelationshipRequest } from '../../util/type';
 @Injectable()
 export class DeleteBlockGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
-    const { relationship } = context
+    const { relationship, user } = context
       .switchToHttp()
       .getRequest() as RelationshipRequest;
     if (relationship !== 'blocker') {
-      throw new NotFoundException('The user had not blocked the other user');
+      throw new NotFoundException(
+        `The user(${user.userId}) had not blocked the other user`,
+      );
     }
     return true;
   }

--- a/backend/src/user/guard/delete-friend.guard.ts
+++ b/backend/src/user/guard/delete-friend.guard.ts
@@ -10,14 +10,14 @@ import { RelationshipRequest } from '../../util/type';
 @Injectable()
 export class DeleteFriendGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
-    const { relationship } = context
+    const { relationship, user } = context
       .switchToHttp()
       .getRequest() as RelationshipRequest;
     if (
       !['friend', 'pendingSender', 'pendingReceiver'].includes(relationship)
     ) {
       throw new NotFoundException(
-        'The user had not received/sent a friend request nor been friends with the other user',
+        `The user(${user.userId}) had not received/sent a friend request nor been friends with the other user`,
       );
     }
     return true;

--- a/backend/src/user/guard/self-check.guard.ts
+++ b/backend/src/user/guard/self-check.guard.ts
@@ -20,7 +20,7 @@ export class SelfCheckGuard implements CanActivate {
     }
     if (req.user.userId === req.targetId) {
       throw new BadRequestException(
-        'The user cannot perform this action on himself/herself',
+        `The user(${req.user.userId}) cannot perform this action on himself/herself`,
       );
     }
     return true;

--- a/backend/src/user/guard/user-exist.guard.ts
+++ b/backend/src/user/guard/user-exist.guard.ts
@@ -39,13 +39,17 @@ export class UserExistGuard implements CanActivate {
           where: { userId: req.targetId },
         }))
       ) {
-        throw new NotFoundException("The user doesn't exist");
+        throw new NotFoundException(
+          `The user with the id (${req.targetId}) doesn't exist`,
+        );
       }
     } catch (e) {
       this.logger.error(e);
       throw e instanceof NotFoundException
         ? e
-        : new InternalServerErrorException("Failed to check user's existence");
+        : new InternalServerErrorException(
+            `Failed to check user's existence for id(${req.targetId})`,
+          );
     }
     return true;
   }

--- a/backend/src/user/user.gateway.ts
+++ b/backend/src/user/user.gateway.ts
@@ -1,111 +1,46 @@
 import { Server } from 'socket.io';
 import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 
-import { SocketId, UserId } from '../util/type';
-import { UserInfoDto } from './dto/user-gateway.dto';
+import { Relationship, SocketId, UserId } from '../util/type';
+import { UserActivityDto } from './dto/user-gateway.dto';
 
 @WebSocketGateway()
 export class UserGateway {
   @WebSocketServer()
   private readonly server: Server;
 
-  /*****************************************************************************
-   *                                                                           *
-   * SECTION : Block / unblock                                                 *
-   *                                                                           *
-   ****************************************************************************/
-
   /**
-   * @description 유저가 차단되었을 때 차단당한 유저에게 누구에게 차단 됐는지 알림
+   * @description 유저가 수신한 friend request 수 변화 전달
    *
-   * @param blockedSocketId 차단당한 유저의 socket id
-   * @param blockedBy 차단한 유저의 id
+   * @param receiverSocketId
+   * @param requestDiff
    */
-  emitBlocked(blockedSocketId: SocketId, blockedBy: UserId) {
-    this.server.to(blockedSocketId).emit('blocked', { blockedBy });
+  emitFriendRequestDiff(receiverSocketId: SocketId, requestDiff: 1 | -1) {
+    this.server.to(receiverSocketId).emit('friendRequestDiff', { requestDiff });
   }
 
   /**
-   * @description 유저가 차단 해제되었을 때 차단 해제된 유저에게 누구에게 차단 해제 됐는지 알림
-   *
-   * @param unblockedSocketId 차단 해제된 유저의 socket id
-   * @param unblockedBy 차단 해제한 유저의 id
-   */
-  emitUnblocked(unblockedSocketId: SocketId, unblockedBy: UserId) {
-    this.server.to(unblockedSocketId).emit('unblocked', { unblockedBy });
-  }
-
-  /*****************************************************************************
-   *                                                                           *
-   * SECTION : Friends                                                         *
-   *                                                                           *
-   ****************************************************************************/
-
-  /**
-   * @description 친구 요청 수락 시 요청한 유저에게 어떤 유저와 친구가 됐는지 알림
-   *
-   * @param senderSocketId 요청한 유저의 socket id
-   * @param newFriendId 요청을 수락한 유저의 id
-   */
-  emitFriendAccepted(senderSocketId: SocketId, newFriendId: UserId) {
-    this.server.to(senderSocketId).emit('friendAccepted', { newFriendId });
-  }
-
-  /**
-   * @description 친구 요청 거절 시 요청한 유저에게 어떤 유저가 요청을 거절했는지 알림
-   *
-   * @param senderSocketId 요청한 유저의 socket id
-   * @param declinedBy 요청을 거절한 유저의 id
-   */
-  emitFriendDeclined(senderSocketId: SocketId, declinedBy: UserId) {
-    this.server.to(senderSocketId).emit('friendDeclined', { declinedBy });
-  }
-
-  /**
-   * @description 친구 요청 취소 시 취소 당한 유저에게 어떤 유저가 요청을 취소했는지 알림
-   *
-   * @param receiverSocketId 취소 당한 유저의 socket id
-   * @param cancelledBy 요청을 취소한 유저의 id
-   */
-  emitFriendCancelled(receiverSocketId: SocketId, cancelledBy: UserId) {
-    this.server.to(receiverSocketId).emit('friendCancelled', { cancelledBy });
-  }
-
-  /**
-   * @description 친구 요청이 왔을 때 요청 받은 유저에게 알림
-   *
-   * @param receiverSocketId 요청 받은 유저의 socket id
-   * @param requesterId 요청한 유저의 id
-   */
-  emitFriendRequest(receiverSocketId: SocketId, requesterId: UserId) {
-    this.server
-      .to(receiverSocketId)
-      .emit('friendRequest', { requestedBy: requesterId });
-  }
-
-  /**
-   * @description 친구가 삭제되었을 때 삭제된 유저에게 알림
-   *
-   * @param removedSocketId 삭제된 유저의 socket id
-   * @param removedBy 삭제한 유저의 id
-   */
-  emitFriendRemoved(removedSocketId: SocketId, removedBy: UserId) {
-    this.server.to(removedSocketId).emit('friendRemoved', { removedBy });
-  }
-
-  /*****************************************************************************
-   *                                                                           *
-   * SECTION : User info                                                       *
-   *                                                                           *
-   ****************************************************************************/
-
-  /**
-   * @description activity & relationship 정보 전달
+   * @description activity 정보 전달
    *
    * @param requesterSocketId 요청한 유저의 socket id
-   * @param userInfo 요청한 유저의 activity & relationship 정보
+   * @param userActivity 요청한 유저의 activity & relationship 정보
    */
-  emitUserInfo(requesterSocketId: SocketId, userInfo: UserInfoDto) {
-    this.server.to(requesterSocketId).emit('userInfo', userInfo);
+  emitUserActivity(requesterSocketId: SocketId, userActivity: UserActivityDto) {
+    this.server.to(requesterSocketId).emit('userActivity', userActivity);
+  }
+
+  /**
+   * @description 유저의 relationship 정보 전달
+   *
+   * @param socketId
+   * @param userId
+   * @param relationship
+   */
+  emitUserRelationship(
+    socketId: SocketId,
+    userId: UserId,
+    relationship: Relationship | 'normal',
+  ) {
+    this.server.to(socketId).emit('userRelationship', { userId, relationship });
   }
 }

--- a/backend/src/user/user.gateway.ts
+++ b/backend/src/user/user.gateway.ts
@@ -2,13 +2,17 @@ import { Server } from 'socket.io';
 import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 
 import { Relationship, SocketId, UserId } from '../util/type';
-import { UserActivityDto } from './dto/user-gateway.dto';
 
 @WebSocketGateway()
 export class UserGateway {
   @WebSocketServer()
   private readonly server: Server;
 
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Public Methods                                                 *
+   *                                                                           *
+   ****************************************************************************/
   /**
    * @description 유저가 수신한 friend request 수 변화 전달
    *
@@ -17,16 +21,6 @@ export class UserGateway {
    */
   emitFriendRequestDiff(receiverSocketId: SocketId, requestDiff: 1 | -1) {
     this.server.to(receiverSocketId).emit('friendRequestDiff', { requestDiff });
-  }
-
-  /**
-   * @description activity 정보 전달
-   *
-   * @param requesterSocketId 요청한 유저의 socket id
-   * @param userActivity 요청한 유저의 activity & relationship 정보
-   */
-  emitUserActivity(requesterSocketId: SocketId, userActivity: UserActivityDto) {
-    this.server.to(requesterSocketId).emit('userActivity', userActivity);
   }
 
   /**

--- a/backend/src/user/user.gateway.ts
+++ b/backend/src/user/user.gateway.ts
@@ -8,11 +8,6 @@ export class UserGateway {
   @WebSocketServer()
   private readonly server: Server;
 
-  /*****************************************************************************
-   *                                                                           *
-   * SECTION : Public Methods                                                 *
-   *                                                                           *
-   ****************************************************************************/
   /**
    * @description 유저가 수신한 friend request 수 변화 전달
    *

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -244,7 +244,7 @@ export class UserService {
     } catch (e) {
       this.logger.error(e);
       throw new InternalServerErrorException(
-        'Failed to find nickname and profileImage of a user',
+        `Failed to find nickname and profileImage of a user(${requesterId})`,
       );
     }
     const requesterSocketId = this.userSocketStorage.clients.get(requesterId);

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -11,7 +11,7 @@ import { ActivityManager } from '../user-status/activity.manager';
 import { ChannelStorage } from '../user-status/channel.storage';
 import { FriendListDto, UserProfileDto } from './dto/user.dto';
 import { UserGateway } from './user.gateway';
-import { UserInfoDto } from './dto/user-gateway.dto';
+import { UserActivityDto } from './dto/user-gateway.dto';
 import { UserRelationshipStorage } from '../user-status/user-relationship.storage';
 import { UserSocketStorage } from '../user-status/user-socket.storage';
 import { Users } from '../entity/users.entity';
@@ -58,7 +58,11 @@ export class UserService {
     await this.userRelationshipStorage.blockUser(blockerId, blockedId);
     const blockedSocketId = this.userSocketStorage.clients.get(blockedId);
     if (blockedSocketId !== undefined) {
-      this.userGateway.emitBlocked(blockedSocketId, blockerId);
+      this.userGateway.emitUserRelationship(
+        blockedSocketId,
+        blockerId,
+        'blocked',
+      );
     }
     return true;
   }
@@ -73,7 +77,11 @@ export class UserService {
     await this.userRelationshipStorage.unblockUser(unblockerId, unblockedId);
     const unblockedSocketId = this.userSocketStorage.clients.get(unblockedId);
     if (unblockedSocketId !== undefined) {
-      this.userGateway.emitUnblocked(unblockedSocketId, unblockerId);
+      this.userGateway.emitUserRelationship(
+        unblockedSocketId,
+        unblockerId,
+        'normal',
+      );
     }
   }
 
@@ -139,7 +147,12 @@ export class UserService {
     await this.userRelationshipStorage.sendFriendRequest(senderId, receiverId);
     const receiverSocketId = this.userSocketStorage.clients.get(receiverId);
     if (receiverSocketId !== undefined) {
-      this.userGateway.emitFriendRequest(receiverSocketId, senderId);
+      this.userGateway.emitFriendRequestDiff(receiverSocketId, 1);
+      this.userGateway.emitUserRelationship(
+        receiverSocketId,
+        senderId,
+        'pendingReceiver',
+      );
     }
     return true;
   }
@@ -158,15 +171,14 @@ export class UserService {
     await this.userRelationshipStorage.deleteFriendship(deleterId, deletedId);
     const deletedSocketId = this.userSocketStorage.clients.get(deletedId);
     if (deletedSocketId !== undefined) {
-      switch (prevRelationship) {
-        case 'friend':
-          this.userGateway.emitFriendRemoved(deletedSocketId, deleterId);
-        case 'pendingSender':
-          this.userGateway.emitFriendCancelled(deletedSocketId, deleterId);
-        case 'pendingReceiver':
-          this.userGateway.emitFriendDeclined(deletedSocketId, deleterId);
-        default:
+      if (prevRelationship === 'pendingSender') {
+        this.userGateway.emitFriendRequestDiff(deletedSocketId, -1);
       }
+      this.userGateway.emitUserRelationship(
+        deletedSocketId,
+        deleterId,
+        'normal',
+      );
     }
   }
 
@@ -189,7 +201,11 @@ export class UserService {
     );
     const acceptedSocketId = this.userSocketStorage.clients.get(acceptedId);
     if (acceptedSocketId !== undefined) {
-      this.userGateway.emitFriendAccepted(acceptedSocketId, accepterId);
+      this.userGateway.emitUserRelationship(
+        acceptedSocketId,
+        accepterId,
+        'friend',
+      );
     }
   }
 
@@ -211,7 +227,7 @@ export class UserService {
    ****************************************************************************/
 
   /**
-   * @description 유저의 닉네임과 프로필 이미지 경로를 반환 & userInfo 이벤트를 송신
+   * @description 유저의 닉네임과 프로필 이미지 경로를 반환 & userActivity & userRelationship 이벤트를 송신
    *
    *
    * @param requesterId 요청한 유저의 ID
@@ -233,9 +249,15 @@ export class UserService {
     }
     const requesterSocketId = this.userSocketStorage.clients.get(requesterId);
     if (requesterSocketId !== undefined) {
-      this.userGateway.emitUserInfo(
+      this.userGateway.emitUserActivity(
         requesterSocketId,
-        this.createUserInfoDto(requesterId, targetId),
+        this.createUserActivityDto(targetId),
+      );
+      this.userGateway.emitUserRelationship(
+        requesterSocketId,
+        targetId,
+        this.userRelationshipStorage.getRelationship(requesterId, targetId) ??
+          'normal',
       );
     }
     return profile;
@@ -248,30 +270,24 @@ export class UserService {
    ****************************************************************************/
 
   /**
-   * @description 유저의 상태 정보를 담은 UserInfoDto 를 생성
+   * @description 유저의 상태 정보를 담은 UserActivityDto 를 생성
    *
-   * @param requesterId 요청하는 유저의 id
    * @param targetId 조회 대상 유저의 id
    * @returns
    */
-  private createUserInfoDto(
-    requesterId: UserId,
-    targetId: UserId,
-  ): UserInfoDto {
+  private createUserActivityDto(targetId: UserId): UserActivityDto {
     let activity: Activity = 'offline';
     const currentUi = this.activityManager.getActivity(targetId);
     if (currentUi) {
       activity = currentUi === 'playingGame' ? 'inGame' : 'online';
     }
+
     // TODO : 게임 중이라면 GameStorage 에서 gameId 가져오기
     const gameId = null;
-    const relationship =
-      this.userRelationshipStorage.getRelationship(requesterId, targetId) ??
-      'normal';
+
     return {
       activity,
       gameId,
-      relationship,
       userId: targetId,
     };
   }

--- a/backend/test/user.e2e-spec.ts
+++ b/backend/test/user.e2e-spec.ts
@@ -17,7 +17,7 @@ import { ChannelStorage } from '../src/user-status/channel.storage';
 import { Channels } from '../src/entity/channels.entity';
 import { Friends } from '../src/entity/friends.entity';
 import { Messages } from '../src/entity/messages.entity';
-import { UserActivityDto } from '../src/user/dto/user-gateway.dto';
+import { UserActivityDto } from '../src/user-status/dto/user-status.dto';
 import { UserRelationshipStorage } from '../src/user-status/user-relationship.storage';
 import { Users } from '../src/entity/users.entity';
 import {


### PR DESCRIPTION
## 개요
- #97 완료

## 작업 사항
- activity 초기값 및 변경 알리는 `userActivity` 이벤트 설정.
  - 유저가 처음으로 `currentUi` 이벤트로 activity 설정할 때 emit.
  - WS disconnection 시 emit.
  - `GET /user/:userId/info` 요청 받았을 때 당시 해당 유저의 activity 정보 emit.
- 관계 초기값 및 변경 알리는 이벤트들 `userRelationship` 으로 통합.

## 변경점
- 에러 메시지에 id 명시.
- ActivityGateway 에서 `userActivity` 이벤트 emit.

close #97 