### PR TITLE
:hammer: chore : Achievers, Achievements, MatchHistory entity 생성 스크립트 추가

### DIFF
--- a/backend/test/generate-mock-data.ts
+++ b/backend/test/generate-mock-data.ts
@@ -2,12 +2,15 @@ import { bufferCount, of } from 'rxjs';
 import { faker } from '@faker-js/faker';
 
 import { AccessMode, Channels } from '../src/entity/channels.entity';
+import { Achievers } from '../src/entity/achievers.entity';
+import { Achievements } from '../src/entity/achievements.entity';
 import { BannedMembers } from '../src/entity/banned-members.entity';
 import { BlockedUsers } from '../src/entity/blocked-users.entity';
 import { ChannelId, UserId } from '../src/util/type';
 import { ChannelMembers } from '../src/entity/channel-members.entity';
 import { DateTimeTransformer } from '../src/entity/date-time.transformer';
 import { Friends } from '../src/entity/friends.entity';
+import { MatchHistory } from '../src/entity/match-history.entity';
 import { Messages } from '../src/entity/messages.entity';
 import { Users } from '../src/entity/users.entity';
 
@@ -194,4 +197,109 @@ export const generateBannedMembers = (members: ChannelMembers[]) => {
     bannedMembers.push(bannedMember);
   });
   return bannedMembers;
+};
+
+export const ACHIEVEMENTS_ENTITIES = [
+  {
+    title: 'one giant leap for mankind.',
+    about:
+      '누군가에겐 미약해 보일 수 있지만, 분명히 그것은 위대한 첫 걸음 입니다. 당신은 처음으로 승리하였습니다.',
+    imagePath: '/asset/achievement/1.png',
+  },
+  {
+    title: 'World Best Ping-Pong Player',
+    about: '초월적인 온라인 탁구 게임에서 1등을 거머쥐었습니다!',
+    imagePath: '/asset/achievement/2.png',
+  },
+  {
+    title: 'Social Animal',
+    about: '무려 10명의 친구! 아리스토텔레스가 당신을 부러워합니다.',
+    imagePath: '/asset/achievement/3.png',
+  },
+  {
+    title: ' Born To Be FT',
+    about:
+      '삶, 우주, 그리고 모든 것에 대한 궁극적인 질문에 대한 해답은 바로 당신!',
+    imagePath: '/asset/achievement/4.png',
+  },
+  {
+    title: 'So noisy~ ',
+    about: 'Join 5 channels',
+    imagePath: '/asset/achievement/5.png',
+  },
+];
+
+export const generateAchievers = (
+  users: Users[],
+  achievements: Achievements[],
+) => {
+  const achievers: Achievers[] = [];
+  users.forEach((user) => {
+    const SIZE = faker.datatype.number({
+      min: 0,
+      max: achievements.length,
+    });
+    for (let i = 0; i < SIZE; ++i) {
+      const achiever = new Achievers();
+      achiever.userId = user.userId;
+      achiever.achievementId = i + 1;
+      achievers.push(achiever);
+    }
+  });
+  return achievers;
+};
+
+export const generateMatchHistory = (users: Users[]) => {
+  const matchHistories: MatchHistory[] = [];
+  users.forEach((user) => {
+    const SIZE = faker.datatype.number({
+      min: 0,
+      max: users.length - 1,
+    });
+    for (let i = 0; i < SIZE; ++i) {
+      const matchHistory = new MatchHistory();
+      matchHistory.userOneId = user.userId;
+      matchHistory.userTwoId = users.filter((u) => u.userId !== user.userId)[
+        i
+      ].userId;
+      matchHistory.userOneScore = faker.datatype.number({
+        min: 0,
+        max: 5,
+      });
+      matchHistory.userTwoScore = faker.datatype.number({
+        min: 0,
+        max: 5,
+      });
+      matchHistory.endAt = new DateTimeTransformer().from(faker.date.past());
+      matchHistory.isRank = faker.datatype.boolean();
+      matchHistories.push(matchHistory);
+    }
+  });
+  return matchHistories;
+};
+
+export const updateUsersFromMatchHistory = (
+  users: Users[],
+  matchHistory: MatchHistory[],
+) => {
+  users.forEach((user) => {
+    const userMatchHistoryAsOne = matchHistory.filter(
+      (history) => history.userOneId === user.userId,
+    );
+    user.winCount = userMatchHistoryAsOne.filter(
+      (history) => history.userOneScore > history.userTwoScore,
+    ).length;
+    user.lossCount = userMatchHistoryAsOne.filter(
+      (history) => history.userOneScore < history.userTwoScore,
+    ).length;
+    const userMatchHistoryAsTwo = matchHistory.filter(
+      (history) => history.userTwoId === user.userId,
+    );
+    user.winCount += userMatchHistoryAsTwo.filter(
+      (history) => history.userOneScore < history.userTwoScore,
+    ).length;
+    user.lossCount += userMatchHistoryAsTwo.filter(
+      (history) => history.userOneScore > history.userTwoScore,
+    ).length;
+  });
 };


### PR DESCRIPTION
## 개요
- ProfileService 테스트를 위한 Achievers, Achievements, MatchHistory entity 생성 스크립트 추가
- MatchHistory 기반으로 Users entity 업데이트하는 스크립트 추가

---

Achievement 상세 내용을 추후에 정해야 할 것 같습니다. 지금은 테스트를 위해 생각나는대로 작성한 상태입니다.