### PR TITLE
:sparkles: feat : GameGateway & GameStorage 부분 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { ApiConfigService } from './config/api-config.service';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ChatsModule } from './chats/chats.module';
+import { GameModule } from './game/game.module';
 import { UserModule } from './user/user.module';
 import { UserStatusModule } from './user-status/user-status.module';
 
@@ -22,6 +23,7 @@ import { UserStatusModule } from './user-status/user-status.module';
       inject: [ApiConfigService],
     }),
     ChatsModule,
+    GameModule,
     UserModule,
     UserStatusModule,
   ],

--- a/backend/src/chats/chats.module.ts
+++ b/backend/src/chats/chats.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { Channels } from '../entity/channels.entity';
@@ -12,7 +12,7 @@ import { Users } from '../entity/users.entity';
 @Module({
   imports: [
     TypeOrmModule.forFeature([Channels, Messages, Users]),
-    UserStatusModule,
+    forwardRef(() => UserStatusModule),
   ],
   controllers: [ChatsController],
   providers: [ChatsGateway, ChatsService],

--- a/backend/src/game/dto/game-gateway.dto.ts
+++ b/backend/src/game/dto/game-gateway.dto.ts
@@ -1,0 +1,28 @@
+import {
+  IsInt,
+  IsString,
+  Length,
+  Min,
+  Max,
+  ArrayUnique,
+} from 'class-validator';
+
+import { GameId } from '../../util/type';
+
+export interface GameStartedDto {
+  id: GameId;
+  left: string;
+  right: string;
+}
+
+export class GameCompleteDto {
+  @IsString()
+  @Length(21)
+  id: GameId;
+
+  @ArrayUnique()
+  @IsInt({ each: true })
+  @Min(0, { each: true })
+  @Max(5, { each: true })
+  scores: [number, number];
+}

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -1,22 +1,90 @@
+import {
+  MessageBody,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
 import { Server } from 'socket.io';
-import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { UsePipes, ValidationPipe } from '@nestjs/common';
 
 import { GameId, SocketId } from '../util/type';
+import { GameCompleteDto, GameStartedDto } from './dto/game-gateway.dto';
+import { GameStorage } from './game.storage';
 
 @WebSocketGateway()
 export class GameGateway {
   @WebSocketServer()
   private readonly server: Server;
 
-  joinRoom(socketId: SocketId, room: `game-${GameId}`) {
+  constructor(private readonly gameStorage: GameStorage) {}
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Public Methods                                                  *
+   *                                                                           *
+   ****************************************************************************/
+
+  /**
+   * @description socket room 입장
+   *
+   * @param socketId socket id
+   * @param room 입장할 room
+   */
+  joinRoom(socketId: SocketId, room: `game-${GameId}` | 'waitingRoom') {
     this.server.in(socketId).socketsJoin(room);
   }
 
+  /**
+   * @description 게임 player 들에게 매칭되었다고 알림
+   *
+   * @param room 게임 방
+   * @param gameId 게임 id
+   */
   emitNewGame(room: `game-${GameId}`, gameId: GameId) {
     this.server.to(room).emit('newGame', { gameId });
   }
 
+  /**
+   * @description: 게임 옵션 전송
+   *
+   * @param room 게임 방
+   * @param map 맵
+   */
   emitGameOption(room: `game-${GameId}`, map: 1 | 2 | 3) {
     this.server.to(room).emit('gameOption', { map });
+  }
+
+  /**
+   * @description 게임 시작 시, waitingRoom UI 에 있는 유저들에게 새 게임 정보 전송
+   *
+   * @param room waitingRoom UI 에 있는 유저들
+   * @param gameStartedDto 게임 시작 정보
+   */
+  emitGameStarted(room: 'waitingRoom', gameStartedDto: GameStartedDto) {
+    this.server.to(room).emit('gameStarted', gameStartedDto);
+  }
+
+  /**
+   * @description 게임 정상 종료 시, 승자가 게임 결과를 서버에 알리는 메시지, 게임 결과 업데이트
+   *
+   * @param result 게임 결과
+   */
+  @UsePipes(new ValidationPipe({ forbidNonWhitelisted: true, whitelist: true }))
+  @SubscribeMessage('gameComplete')
+  async handleGameComplete(@MessageBody() result: GameCompleteDto) {
+    const { id, scores } = result;
+    this.server.socketsLeave(`game-${id}`);
+    await this.gameStorage.updateResult(id, scores);
+    this.gameStorage.games.delete(id);
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * NOTE : TEST ONLY                                                          *
+   *                                                                           *
+   ****************************************************************************/
+
+  doesRoomExist(room: `game-${GameId}`) {
+    return this.server.sockets.adapter.rooms.get(room) !== undefined;
   }
 }

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -1,0 +1,22 @@
+import { Server } from 'socket.io';
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+
+import { GameId, SocketId } from '../util/type';
+
+@WebSocketGateway()
+export class GameGateway {
+  @WebSocketServer()
+  private readonly server: Server;
+
+  joinRoom(socketId: SocketId, room: `game-${GameId}`) {
+    this.server.in(socketId).socketsJoin(room);
+  }
+
+  emitNewGame(room: `game-${GameId}`, gameId: GameId) {
+    this.server.to(room).emit('newGame', { gameId });
+  }
+
+  emitGameOption(room: `game-${GameId}`, map: 1 | 2 | 3) {
+    this.server.to(room).emit('gameOption', { map });
+  }
+}

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { GameGateway } from './game.gateway';
 import { GameStorage } from './game.storage';
+import { MatchHistory } from '../entity/match-history.entity';
+import { Users } from '../entity/users.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([MatchHistory, Users])],
   providers: [GameGateway, GameStorage],
+  exports: [GameGateway, GameStorage],
 })
 export class GameModule {}

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { GameStorage } from './game.storage';
+
+@Module({
+  providers: [GameStorage],
+})
+export class GameModule {}

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+
+import { GameGateway } from './game.gateway';
 import { GameStorage } from './game.storage';
 
 @Module({
-  providers: [GameStorage],
+  providers: [GameGateway, GameStorage],
 })
 export class GameModule {}

--- a/backend/src/game/game.storage.ts
+++ b/backend/src/game/game.storage.ts
@@ -1,9 +1,111 @@
-import { Injectable } from '@nestjs/common';
+import { DataSource, In } from 'typeorm';
+import { DateTime } from 'luxon';
+import { InjectDataSource } from '@nestjs/typeorm';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 
-import { GameId, GameInfo } from '../util/type';
+import { GameId, GameInfo, UserId } from '../util/type';
+import { MatchHistory } from '../entity/match-history.entity';
+import { Users } from '../entity/users.entity';
 
 @Injectable()
 export class GameStorage {
-  readonly ladderGames = new Map<GameId, GameInfo>();
-  readonly normalGames = new Map<GameId, GameInfo>();
+  readonly games = new Map<GameId, GameInfo>();
+  private readonly logger = new Logger(GameStorage.name);
+
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource,
+  ) {}
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Public Methods                                                  *
+   *                                                                           *
+   ****************************************************************************/
+
+  /**
+   * @description 게임 종료 후 게임 결과 업데이트
+   *
+   * @param id 게임 id
+   * @param scores 스코어
+   * @param isRank ladder ? true : false
+   */
+  async updateResult(gameId: GameId, scores: [number, number]) {
+    const { leftId, rightId, isRank } = this.games.get(gameId);
+    const [winnerId, loserId] =
+      scores[0] > scores[1] ? [leftId, rightId] : [rightId, leftId];
+    const winnerPartialEntity = { winCount: () => 'win_count + 1' };
+    let ladderRise = 0;
+    if (isRank) {
+      ladderRise = await this.calculateLadderRise(winnerId, loserId, scores);
+      winnerPartialEntity['ladder'] = () => `ladder + ${ladderRise}`;
+    }
+    try {
+      await this.dataSource.manager.transaction(async (manager) => {
+        await manager.save(MatchHistory, {
+          userOneId: leftId,
+          userTwoId: rightId,
+          userOneScore: scores[0],
+          userTwoScore: scores[1],
+          isRank,
+          endAt: DateTime.now(),
+        });
+        await manager.update(Users, winnerId, winnerPartialEntity);
+        await manager.update(Users, loserId, {
+          lossCount: () => 'loss_count + 1',
+        });
+      });
+    } catch (e) {
+      this.logger.error(e);
+      throw new InternalServerErrorException(
+        `Failed to update the game result between ${leftId} and ${rightId}`,
+      );
+    }
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Private Methods                                                 *
+   *                                                                           *
+   ****************************************************************************/
+
+  /**
+   * @description 래더 점수 계산
+   *
+   * @param winnerId 승자 id
+   * @param loserId 패자 id
+   * @param scores 스코어
+   * @returns 래더 점수
+   */
+  async calculateLadderRise(
+    winnerId: UserId,
+    loserId: UserId,
+    scores: [number, number],
+  ) {
+    let beforeGame: Users[];
+    try {
+      beforeGame = await this.dataSource.manager.find(Users, {
+        select: ['userId', 'ladder'],
+        where: { userId: In([winnerId, loserId]) },
+      });
+    } catch (e) {
+      this.logger.error(e);
+      throw new InternalServerErrorException(
+        `Failed to calculate ladder rise for the winner ${winnerId}`,
+      );
+    }
+    const [winnerLadder, loserLadder] =
+      beforeGame[0].userId === winnerId
+        ? [beforeGame[0].ladder, beforeGame[1].ladder]
+        : [beforeGame[1].ladder, beforeGame[0].ladder];
+    const scoreGap = Math.abs(scores[0] - scores[1]);
+    const ladderGap = Math.abs(winnerLadder - loserLadder);
+    return winnerLadder >= loserLadder
+      ? Math.max(Math.floor(scoreGap * (1 - ladderGap / 42)), 1)
+      : Math.floor(scoreGap * (1 + ladderGap / 42));
+  }
 }

--- a/backend/src/game/game.storage.ts
+++ b/backend/src/game/game.storage.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+
+import { GameId, GameInfo } from '../util/type';
+
+@Injectable()
+export class GameStorage {
+  readonly ladderGames = new Map<GameId, GameInfo>();
+  readonly normalGames = new Map<GameId, GameInfo>();
+}

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -65,9 +65,11 @@ export class ActivityGateway
       this.userRelationshipStorage.load(userId),
       this.channelStorage.loadUser(userId),
     ]);
-    const joinedChannels = this.channelStorage.getUser(userId).keys();
-    for (const channelId of joinedChannels) {
-      this.chatsGateway.joinChannelRoom(channelId, userId);
+    const joinedChannels = this.channelStorage.getUser(userId)?.keys();
+    if (joinedChannels !== undefined) {
+      for (const channelId of joinedChannels) {
+        this.chatsGateway.joinChannelRoom(channelId, userId);
+      }
     }
   }
 

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -15,6 +15,7 @@ import { ActivityManager } from './activity.manager';
 import { ChannelStorage } from './channel.storage';
 import { ChatsGateway } from '../chats/chats.gateway';
 import { CurrentUiDto } from './dto/user-status.dto';
+import { GameGateway } from '../game/game.gateway';
 import { UserActivityDto } from './dto/user-status.dto';
 import { UserRelationshipStorage } from './user-relationship.storage';
 import { UserSocketStorage } from './user-socket.storage';
@@ -35,13 +36,13 @@ export class ActivityGateway
 
   constructor(
     private activityManager: ActivityManager,
-    private userRelationshipStorage: UserRelationshipStorage,
-    private userSocketStorage: UserSocketStorage,
     private channelStorage: ChannelStorage,
     private chatsGateway: ChatsGateway,
+    private gameGateway: GameGateway,
+    private userRelationshipStorage: UserRelationshipStorage,
+    private userSocketStorage: UserSocketStorage,
   ) /**
    * private authService: AuthService,
-   * private gameGateway: GameGateway,
    * private ranksGateway: RanksGateway, */ {}
 
   /**
@@ -125,6 +126,8 @@ export class ActivityGateway
       );
       this.chatsGateway.joinActiveRoom(clientSocket.id, room);
       this.chatsGateway.joinRoom(clientSocket.id, room);
+    } else if (ui === 'waitingRoom') {
+      this.gameGateway.joinRoom(clientSocket.id, 'waitingRoom');
     }
     this.activityManager.setActivity(userId, ui);
     if (!prevActivity) {

--- a/backend/src/user-status/channel.storage.spec.ts
+++ b/backend/src/user-status/channel.storage.spec.ts
@@ -593,7 +593,7 @@ describe('ChannelStorage', () => {
     );
     await storage.addUserToChannel(nonDmChannel, member.userId);
     const banEndAt = DateTime.now().plus({ hours: 1 });
-    await storage.banUser(nonDmChannel, owner.userId, member.userId, banEndAt);
+    await storage.banUser(nonDmChannel, member.userId, banEndAt);
 
     expect(
       (

--- a/backend/src/user-status/user-status.module.ts
+++ b/backend/src/user-status/user-status.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ActivityGateway } from './activity.gateway';
@@ -8,7 +8,7 @@ import { BlockedUsers } from '../entity/blocked-users.entity';
 import { ChannelMembers } from '../entity/channel-members.entity';
 import { ChannelStorage } from './channel.storage';
 import { Channels } from '../entity/channels.entity';
-import { ChatsGateway } from '../chats/chats.gateway';
+import { ChatsModule } from '../chats/chats.module';
 import { Friends } from '../entity/friends.entity';
 import { GameModule } from '../game/game.module';
 import { MatchHistory } from '../entity/match-history.entity';
@@ -29,13 +29,13 @@ import { Users } from '../entity/users.entity';
       Messages,
       Users,
     ]),
+    forwardRef(() => ChatsModule),
     GameModule,
   ],
   providers: [
     ActivityGateway,
     ActivityManager,
     ChannelStorage,
-    ChatsGateway,
     UserRelationshipStorage,
     UserSocketStorage,
   ],

--- a/backend/src/user-status/user-status.module.ts
+++ b/backend/src/user-status/user-status.module.ts
@@ -10,6 +10,8 @@ import { ChannelStorage } from './channel.storage';
 import { Channels } from '../entity/channels.entity';
 import { ChatsGateway } from '../chats/chats.gateway';
 import { Friends } from '../entity/friends.entity';
+import { GameModule } from '../game/game.module';
+import { MatchHistory } from '../entity/match-history.entity';
 import { Messages } from '../entity/messages.entity';
 import { UserRelationshipStorage } from './user-relationship.storage';
 import { UserSocketStorage } from './user-socket.storage';
@@ -23,9 +25,11 @@ import { Users } from '../entity/users.entity';
       ChannelMembers,
       Channels,
       Friends,
+      MatchHistory,
       Messages,
       Users,
     ]),
+    GameModule,
   ],
   providers: [
     ActivityGateway,

--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -5,6 +5,8 @@ export type UserId = number;
 
 export type ChannelId = number;
 
+export type GameId = string;
+
 export type Friendship = 'friend' | 'pendingSender' | 'pendingReceiver';
 
 export type BlockRelationship = 'blocker' | 'blocked';
@@ -40,6 +42,12 @@ export type CurrentUi =
   | 'waitingRoom';
 
 export type Activity = 'online' | 'offline' | 'inGame';
+
+export interface GameInfo {
+  left: UserId;
+  right: UserId;
+  map: 1 | 2 | 3;
+}
 
 export interface VerifiedRequest extends Request {
   user: { userId: UserId };

--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon';
 import { Request } from 'express';
+import { Users } from '../entity/users.entity';
 
 export type UserId = number;
 
@@ -43,10 +44,20 @@ export type CurrentUi =
 
 export type Activity = 'online' | 'offline' | 'inGame';
 
-export interface GameInfo {
+export class GameInfo {
+  constructor(leftUser: Users, rightUsers: Users, map, isRank: boolean) {
+    this.leftId = leftUser.userId;
+    this.leftNickname = leftUser.nickname;
+    this.rightId = rightUsers.userId;
+    this.rightNickname = rightUsers.nickname;
+    this.map = map;
+    this.isRank = isRank;
+  }
+
+  isRank: boolean;
   leftId: UserId;
   leftNickname: string;
-  right: UserId;
+  rightId: UserId;
   rightNickname: string;
   map: 1 | 2 | 3;
 }

--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -44,8 +44,10 @@ export type CurrentUi =
 export type Activity = 'online' | 'offline' | 'inGame';
 
 export interface GameInfo {
-  left: UserId;
+  leftId: UserId;
+  leftNickname: string;
   right: UserId;
+  rightNickname: string;
   map: 1 | 2 | 3;
 }
 

--- a/backend/test/game-gateway.e2e-spec.ts
+++ b/backend/test/game-gateway.e2e-spec.ts
@@ -1,45 +1,94 @@
+import { DataSource, In } from 'typeorm';
 import { INestApplication } from '@nestjs/common';
 import { Socket, io } from 'socket.io-client';
 import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { faker } from '@faker-js/faker';
+import { nanoid } from 'nanoid';
+import waitForExpect from 'wait-for-expect';
 
+import { ActivityManager } from '../src/user-status/activity.manager';
 import { AppModule } from '../src/app.module';
+import { BannedMembers } from '../src/entity/banned-members.entity';
+import { BlockedUsers } from '../src/entity/blocked-users.entity';
+import { ChannelMembers } from '../src/entity/channel-members.entity';
+import { Channels } from '../src/entity/channels.entity';
+import { Friends } from '../src/entity/friends.entity';
+import { GameId, GameInfo, UserId } from '../src/util/type';
 import { GameGateway } from '../src/game/game.gateway';
-import { UserId } from '../src/util/type';
+import { GameStorage } from '../src/game/game.storage';
+import { MatchHistory } from '../src/entity/match-history.entity';
+import { Messages } from '../src/entity/messages.entity';
+import {
+  TYPEORM_SHARED_CONFIG,
+  createDataSources,
+  destroyDataSources,
+} from './db-resource-manager';
 import { UserSocketStorage } from '../src/user-status/user-socket.storage';
 import { Users } from '../src/entity/users.entity';
 import { generateUsers } from './generate-mock-data';
-import { nanoid } from 'nanoid';
 import { timeout } from './util';
 
 const URL = 'http://localhost:4247';
 
+const TEST_DB = 'test_db_game_gateway';
+const ENTITIES = [
+  BannedMembers,
+  BlockedUsers,
+  ChannelMembers,
+  Channels,
+  Friends,
+  MatchHistory,
+  Messages,
+  Users,
+];
+
+process.env.NODE_ENV = 'development';
+
 describe('GameGateway (e2e)', () => {
   let app: INestApplication;
+  let activityManager: ActivityManager;
   let clientSockets: Socket[];
+  let dataSource: DataSource;
+  let initDataSource: DataSource;
+  let gameStorage: GameStorage;
   let gateway: GameGateway;
   let usersEntities: Users[];
+  let users: Users[];
   let userIds: UserId[];
   let userSocketStorage: UserSocketStorage;
+  let gameId: GameId;
   let index = 0;
 
   beforeAll(async () => {
-    usersEntities = generateUsers(30);
+    const dataSources = await createDataSources(TEST_DB, ENTITIES);
+    initDataSource = dataSources.initDataSource;
+    dataSource = dataSources.dataSource;
+    usersEntities = generateUsers(64);
+    await dataSource.manager.save(usersEntities);
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [AppModule],
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          ...TYPEORM_SHARED_CONFIG,
+          autoLoadEntities: true,
+          database: TEST_DB,
+        }),
+        AppModule,
+      ],
     }).compile();
     app = moduleFixture.createNestApplication();
     await app.init();
     await app.listen(4247);
     gateway = app.get(GameGateway);
     userSocketStorage = app.get(UserSocketStorage);
+    activityManager = app.get(ActivityManager);
+    gameStorage = app.get(GameStorage);
   });
 
   beforeEach(async () => {
-    userIds = [
-      usersEntities[index++].userId,
-      usersEntities[index++].userId,
-      usersEntities[index++].userId,
-    ];
+    users = [usersEntities[index++], usersEntities[index++]];
+    userIds = users.map(({ userId }) => userId);
     clientSockets = userIds.map((userId) =>
       io(URL, { extraHeaders: { 'x-user-id': userId.toString() } }),
     );
@@ -49,18 +98,19 @@ describe('GameGateway (e2e)', () => {
           new Promise((resolve) => socket.on('connect', () => resolve('done'))),
       ),
     );
+    gameId = nanoid();
   });
 
-  afterEach(() => {
-    clientSockets.forEach((socket) => socket.disconnect());
-  });
+  afterEach(() => clientSockets.forEach((socket) => socket.disconnect()));
 
-  afterAll(async () => await app.close());
+  afterAll(async () => {
+    await app.close();
+    await destroyDataSources(TEST_DB, dataSource, initDataSource);
+  });
 
   describe('newGame', () => {
     it('should notify both users when a new game is matched (ladder)', async () => {
       const [playerOne, playerTwo] = clientSockets;
-      const gameId = nanoid();
       gateway.joinRoom(
         userSocketStorage.clients.get(userIds[0]),
         `game-${gameId}`,
@@ -84,7 +134,6 @@ describe('GameGateway (e2e)', () => {
 
     it('should notify only the invited when a user invites another user to a game (normal)', async () => {
       const [playerOne, playerTwo] = clientSockets;
-      const gameId = nanoid();
       gateway.joinRoom(
         userSocketStorage.clients.get(userIds[0]),
         `game-${gameId}`,
@@ -109,14 +158,182 @@ describe('GameGateway (e2e)', () => {
     });
   });
 
-  // describe('gameStarted', () => {
-  //   it('should notify all players that are at /waiting-room UI that a new game has been started', async () => {});
-  // });
+  describe('gameStarted', () => {
+    beforeEach(async () => {
+      users.push(usersEntities[index++], usersEntities[index++]);
+      userIds = users.map(({ userId }) => userId);
+      clientSockets.push(
+        io(URL, { extraHeaders: { 'x-user-id': userIds[2].toString() } }),
+        io(URL, { extraHeaders: { 'x-user-id': userIds[3].toString() } }),
+      );
+      await Promise.all([
+        new Promise((resolve) =>
+          clientSockets[2].on('connect', () => resolve('done')),
+        ),
+        new Promise((resolve) =>
+          clientSockets[3].on('connect', () => resolve('done')),
+        ),
+      ]);
+    });
+
+    it('should notify all players that are in /waiting-room UI when a new game has been started', async () => {
+      const [playerOne, playerTwo, userOne, userTwo] = clientSockets;
+      userOne.emit('currentUi', { userId: userIds[2], ui: 'waitingRoom' });
+      userTwo.emit('currentUi', { userId: userIds[3], ui: 'waitingRoom' });
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(userIds[2])).toEqual('waitingRoom');
+        expect(activityManager.getActivity(userIds[3])).toEqual('waitingRoom');
+      });
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[0]),
+        `game-${gameId}`,
+      );
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[1]),
+        `game-${gameId}`,
+      );
+      const [
+        newGameOne,
+        newGameTwo,
+        newGameFailOne,
+        newGameFailTwo,
+        gameStartedFailOne,
+        gameStartedFailTwo,
+        gameStartedOne,
+        gameStartedTwo,
+      ] = await Promise.allSettled([
+        new Promise((res) => playerOne.on('newGame', (data) => res(data))),
+        new Promise((res) => playerTwo.on('newGame', (data) => res(data))),
+        timeout(
+          1000,
+          new Promise((res) => userOne.on('newGame', (data) => res(data))),
+        ),
+        timeout(
+          1000,
+          new Promise((res) => userTwo.on('newGame', (data) => res(data))),
+        ),
+        timeout(
+          1000,
+          new Promise((res) =>
+            playerOne.on('gameStarted', (data) => res(data)),
+          ),
+        ),
+        timeout(
+          1000,
+          new Promise((res) =>
+            playerTwo.on('gameStarted', (data) => res(data)),
+          ),
+        ),
+        new Promise((res) => userOne.on('gameStarted', (data) => res(data))),
+        new Promise((res) => userTwo.on('gameStarted', (data) => res(data))),
+        gateway.emitNewGame(`game-${gameId}`, gameId),
+        gateway.emitGameStarted('waitingRoom', {
+          id: gameId,
+          left: users[0].nickname,
+          right: users[1].nickname,
+        }),
+      ]);
+      expect(newGameFailOne.status).toEqual('rejected');
+      expect(newGameFailTwo.status).toEqual('rejected');
+      expect(gameStartedFailOne.status).toEqual('rejected');
+      expect(gameStartedFailTwo.status).toEqual('rejected');
+      expect(newGameOne.status).toEqual('fulfilled');
+      expect(newGameTwo.status).toEqual('fulfilled');
+      if (
+        gameStartedOne.status === 'rejected' ||
+        gameStartedTwo.status === 'rejected'
+      ) {
+        fail();
+      }
+      expect(gameStartedOne.value).toEqual(gameStartedTwo.value);
+      expect(gameStartedOne.value).toEqual({
+        id: gameId,
+        left: users[0].nickname,
+        right: users[1].nickname,
+      });
+    });
+
+    it('should notify only to the players that are in /waiting-room UI when a new game has been started', async () => {
+      const [playerOne, playerTwo, userOne, userTwo] = clientSockets;
+      userOne.emit('currentUi', { userId: userIds[2], ui: 'profile' });
+      userTwo.emit('currentUi', { userId: userIds[3], ui: 'waitingRoom' });
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(userIds[2])).toEqual('profile');
+        expect(activityManager.getActivity(userIds[3])).toEqual('waitingRoom');
+      });
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[0]),
+        `game-${gameId}`,
+      );
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[1]),
+        `game-${gameId}`,
+      );
+      const [
+        newGameOne,
+        newGameTwo,
+        newGameFailOne,
+        newGameFailTwo,
+        gameStartedFailOne,
+        gameStartedFailTwo,
+        gameStartedFailThree,
+        gameStartedOne,
+      ] = await Promise.allSettled([
+        new Promise((res) => playerOne.on('newGame', (data) => res(data))),
+        new Promise((res) => playerTwo.on('newGame', (data) => res(data))),
+        timeout(
+          1000,
+          new Promise((res) => userOne.on('newGame', (data) => res(data))),
+        ),
+        timeout(
+          1000,
+          new Promise((res) => userTwo.on('newGame', (data) => res(data))),
+        ),
+        timeout(
+          1000,
+          new Promise((res) =>
+            playerOne.on('gameStarted', (data) => res(data)),
+          ),
+        ),
+        timeout(
+          1000,
+          new Promise((res) =>
+            playerTwo.on('gameStarted', (data) => res(data)),
+          ),
+        ),
+        timeout(
+          1000,
+          new Promise((res) => userOne.on('gameStarted', (data) => res(data))),
+        ),
+        new Promise((res) => userTwo.on('gameStarted', (data) => res(data))),
+        gateway.emitNewGame(`game-${gameId}`, gameId),
+        gateway.emitGameStarted('waitingRoom', {
+          id: gameId,
+          left: users[0].nickname,
+          right: users[1].nickname,
+        }),
+      ]);
+      expect(newGameFailOne.status).toEqual('rejected');
+      expect(newGameFailTwo.status).toEqual('rejected');
+      expect(gameStartedFailOne.status).toEqual('rejected');
+      expect(gameStartedFailTwo.status).toEqual('rejected');
+      expect(gameStartedFailThree.status).toEqual('rejected');
+      expect(newGameOne.status).toEqual('fulfilled');
+      expect(newGameTwo.status).toEqual('fulfilled');
+      if (gameStartedOne.status === 'rejected') {
+        fail();
+      }
+      expect(gameStartedOne.value).toEqual({
+        id: gameId,
+        left: users[0].nickname,
+        right: users[1].nickname,
+      });
+    });
+  });
 
   describe('gameOption', () => {
     it('should notify the invited that the game option has been changed', async () => {
       const [playerOne] = clientSockets;
-      const gameId = nanoid();
       gateway.joinRoom(
         userSocketStorage.clients.get(userIds[0]),
         `game-${gameId}`,
@@ -131,30 +348,271 @@ describe('GameGateway (e2e)', () => {
     });
   });
 
-  // TODO : 추후에 클라이언트에서 라이브로 전달되어야하는 데이터가 파악되면 구현
-  // describe('gameStatus', () => {
-  //   it('should notify both players of the games current status', async () => {
-  //     const [playerOne, playerTwo] = clientSockets;
-  //     const gameId = nanoid();
-  //     gateway.joinRoom(
-  //       userSocketStorage.clients.get(userIds[0]),
-  //       `game-${gameId}`,
-  //     );
-  //     gateway.joinRoom(
-  //       userSocketStorage.clients.get(userIds[1]),
-  //       `game-${gameId}`,
-  //     );
-  //     const [wsMessageOne, wsMessageTwo] = await Promise.all([
-  //       new Promise((resolve) =>
-  //         playerOne.on('gameStatus', (data) => resolve(data)),
-  //       ),
-  //       new Promise((resolve) =>
-  //         playerTwo.on('gameStatus', (data) => resolve(data)),
-  //       ),
-  //       gateway.emitGameStatus(`game-${gameId}`, 'started'),
-  //     ]);
-  //     expect(wsMessageOne).toEqual({ status: 'started' });
-  //     expect(wsMessageTwo).toEqual({ status: 'started' });
-  //   });
-  // });
+  describe('gameComplete', () => {
+    it('should throw error when the client sends invalid message', async () => {
+      const [playerOne] = clientSockets;
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[0]),
+        `game-${gameId}`,
+      );
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[1]),
+        `game-${gameId}`,
+      );
+      gameStorage.games.set(gameId, new GameInfo(users[0], users[1], 1, true));
+      playerOne.emit('gameComplete', { id: gameId }); // no scores
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(gameStorage.games.get(gameId)).toBeDefined();
+      expect(gateway.doesRoomExist(`game-${gameId}`)).toBeTruthy();
+      playerOne.emit('gameComplete', { id: '0123456789abcdefghij' }); // invalid gameId (20 bytes)
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(gameStorage.games.get(gameId)).toBeDefined();
+      expect(gateway.doesRoomExist(`game-${gameId}`)).toBeTruthy();
+      playerOne.emit('gameComplete', { id: gameId, scores: [0, 'a'] }); // invalid scores
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(gameStorage.games.get(gameId)).toBeDefined();
+      expect(gateway.doesRoomExist(`game-${gameId}`)).toBeTruthy();
+      playerOne.emit('gameComplete', { id: gameId, scores: [0, 6] }); // invalid scores out of range
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(gameStorage.games.get(gameId)).toBeDefined();
+      expect(gateway.doesRoomExist(`game-${gameId}`)).toBeTruthy();
+      playerOne.emit('gameComplete', { id: gameId, scores: [0, 6], hi: 'hi' }); // non existing property
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(gameStorage.games.get(gameId)).toBeDefined();
+      expect(gateway.doesRoomExist(`game-${gameId}`)).toBeTruthy();
+    });
+
+    it('should destroy room and update match result when a game ends (left wins, ladder)', async () => {
+      const playerOne = clientSockets[0];
+      const prevGame = await dataSource.manager.find(Users, {
+        select: ['userId', 'winCount', 'lossCount', 'ladder'],
+        where: { userId: In(userIds) },
+      });
+      expect(prevGame.length).toBe(2);
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[0]),
+        `game-${gameId}`,
+      );
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[1]),
+        `game-${gameId}`,
+      );
+      gameStorage.games.set(gameId, new GameInfo(users[0], users[1], 1, true));
+      const scores = [5, faker.datatype.number({ min: 0, max: 4 })];
+      playerOne.emit('gameComplete', {
+        id: gameId,
+        scores,
+      });
+      await waitForExpect(async () => {
+        expect(gameStorage.games.get(gameId)).toBeUndefined();
+        expect(gateway.doesRoomExist(`game-${gameId}`)).toBeFalsy();
+      });
+      expect(
+        await dataSource.manager.countBy(MatchHistory, {
+          userOneId: userIds[0],
+          userTwoId: userIds[1],
+        }),
+      ).toEqual(1);
+      const postGame = await dataSource.manager.find(Users, {
+        select: ['userId', 'winCount', 'lossCount', 'ladder'],
+        where: { userId: In(userIds) },
+      });
+      const { prevWinner, prevLoser, postWinner, postLoser } = winnerLoserStats(
+        prevGame,
+        postGame,
+        userIds[0],
+      );
+      const ladderRise = calculateLadderRise(
+        prevWinner.ladder,
+        prevLoser.ladder,
+        scores,
+        prevWinner.ladder >= prevLoser.ladder,
+      );
+      expect(postGame.length).toBe(2);
+      expect(postWinner).toMatchObject({
+        winCount: prevWinner.winCount + 1,
+        lossCount: prevWinner.lossCount,
+        ladder: prevWinner.ladder + ladderRise,
+      });
+      expect(postLoser).toMatchObject({
+        winCount: prevLoser.winCount,
+        lossCount: prevLoser.lossCount + 1,
+        ladder: prevLoser.ladder,
+      });
+    });
+
+    it('should destroy room and update match result when a game ends (right wins, ladder)', async () => {
+      const playerTwo = clientSockets[1];
+      const prevGame = await dataSource.manager.find(Users, {
+        select: ['userId', 'winCount', 'lossCount', 'ladder'],
+        where: { userId: In(userIds) },
+      });
+      expect(prevGame.length).toBe(2);
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[0]),
+        `game-${gameId}`,
+      );
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[1]),
+        `game-${gameId}`,
+      );
+      gameStorage.games.set(gameId, new GameInfo(users[0], users[1], 1, true));
+      const scores = [faker.datatype.number({ min: 0, max: 4 }), 5];
+      playerTwo.emit('gameComplete', {
+        id: gameId,
+        scores,
+      });
+      await waitForExpect(async () => {
+        expect(gameStorage.games.get(gameId)).toBeUndefined();
+        expect(gateway.doesRoomExist(`game-${gameId}`)).toBeFalsy();
+      });
+      expect(
+        await dataSource.manager.countBy(MatchHistory, {
+          userOneId: userIds[0],
+          userTwoId: userIds[1],
+        }),
+      ).toEqual(1);
+      const postGame = await dataSource.manager.find(Users, {
+        select: ['userId', 'winCount', 'lossCount', 'ladder'],
+        where: { userId: In(userIds) },
+      });
+      const { prevWinner, prevLoser, postWinner, postLoser } = winnerLoserStats(
+        prevGame,
+        postGame,
+        userIds[1],
+      );
+      const ladderRise = calculateLadderRise(
+        prevWinner.ladder,
+        prevLoser.ladder,
+        scores,
+        prevWinner.ladder >= prevLoser.ladder,
+      );
+      expect(postGame.length).toBe(2);
+      expect(postWinner).toMatchObject({
+        winCount: prevWinner.winCount + 1,
+        lossCount: prevWinner.lossCount,
+        ladder: prevWinner.ladder + ladderRise,
+      });
+      expect(postLoser).toMatchObject({
+        winCount: prevLoser.winCount,
+        lossCount: prevLoser.lossCount + 1,
+        ladder: prevLoser.ladder,
+      });
+    });
+
+    it('should not update ladder when the normal game ends', async () => {
+      const playerOne = clientSockets[0];
+      const prevGame = await dataSource.manager.find(Users, {
+        select: ['userId', 'winCount', 'lossCount', 'ladder'],
+        where: { userId: In(userIds) },
+      });
+      expect(prevGame.length).toBe(2);
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[0]),
+        `game-${gameId}`,
+      );
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[1]),
+        `game-${gameId}`,
+      );
+      gameStorage.games.set(gameId, new GameInfo(users[0], users[1], 1, false));
+      const scores = [5, faker.datatype.number({ min: 0, max: 4 })];
+      playerOne.emit('gameComplete', {
+        id: gameId,
+        scores,
+      });
+      await waitForExpect(async () => {
+        expect(gameStorage.games.get(gameId)).toBeUndefined();
+        expect(gateway.doesRoomExist(`game-${gameId}`)).toBeFalsy();
+      });
+      expect(
+        await dataSource.manager.countBy(MatchHistory, {
+          userOneId: userIds[0],
+          userTwoId: userIds[1],
+        }),
+      ).toEqual(1);
+      const postGame = await dataSource.manager.find(Users, {
+        select: ['userId', 'winCount', 'lossCount', 'ladder'],
+        where: { userId: In(userIds) },
+      });
+      const { prevWinner, prevLoser, postWinner, postLoser } = winnerLoserStats(
+        prevGame,
+        postGame,
+        userIds[0],
+      );
+      expect(postGame.length).toBe(2);
+      expect(postWinner).toMatchObject({
+        winCount: prevWinner.winCount + 1,
+        lossCount: prevWinner.lossCount,
+        ladder: prevWinner.ladder,
+      });
+      expect(postLoser).toMatchObject({
+        winCount: prevLoser.winCount,
+        lossCount: prevLoser.lossCount + 1,
+        ladder: prevLoser.ladder,
+      });
+    });
+
+    /*****************************************************************************
+     *                                                                           *
+     * SECTION : Utils                                                           *
+     *                                                                           *
+     ****************************************************************************/
+
+    const calculateLadderRise = (
+      winnerLadder: number,
+      loserLadder: number,
+      scores: number[],
+      isHigher: boolean,
+    ) => {
+      const ladderGap = Math.abs(winnerLadder - loserLadder);
+      const scoreGap = Math.abs(scores[0] - scores[1]);
+      return isHigher
+        ? Math.max(Math.floor(scoreGap * (1 - ladderGap / 42)), 1)
+        : Math.floor(scoreGap * (1 + ladderGap / 42));
+    };
+
+    const winnerLoserStats = (
+      prevGame: Users[],
+      postGame: Users[],
+      winnerId: UserId,
+    ) => {
+      const [prevWinner, prevLoser] =
+        prevGame[0].userId === winnerId
+          ? [prevGame[0], prevGame[1]]
+          : [prevGame[1], prevGame[0]];
+      const [postWinner, postLoser] =
+        postGame[0].userId === winnerId
+          ? [postGame[0], postGame[1]]
+          : [postGame[1], postGame[0]];
+      return { prevWinner, prevLoser, postWinner, postLoser };
+    };
+  });
 });
+
+// TODO : 추후에 클라이언트에서 라이브로 전달되어야하는 데이터가 파악되면 구현
+// describe('gameStatus', () => {
+//   it('should notify both players of the games current status', async () => {
+//     const [playerOne, playerTwo] = clientSockets;
+//     const gameId = nanoid();
+//     gateway.joinRoom(
+//       userSocketStorage.clients.get(userIds[0]),
+//       `game-${gameId}`,
+//     );
+//     gateway.joinRoom(
+//       userSocketStorage.clients.get(userIds[1]),
+//       `game-${gameId}`,
+//     );
+//     const [wsMessageOne, wsMessageTwo] = await Promise.all([
+//       new Promise((resolve) =>
+//         playerOne.on('gameStatus', (data) => resolve(data)),
+//       ),
+//       new Promise((resolve) =>
+//         playerTwo.on('gameStatus', (data) => resolve(data)),
+//       ),
+//       gateway.emitGameStatus(`game-${gameId}`, 'started'),
+//     ]);
+//     expect(wsMessageOne).toEqual({ status: 'started' });
+//     expect(wsMessageTwo).toEqual({ status: 'started' });
+//   });
+// });

--- a/backend/test/game-gateway.e2e-spec.ts
+++ b/backend/test/game-gateway.e2e-spec.ts
@@ -1,0 +1,160 @@
+import { INestApplication } from '@nestjs/common';
+import { Socket, io } from 'socket.io-client';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { AppModule } from '../src/app.module';
+import { GameGateway } from '../src/game/game.gateway';
+import { UserId } from '../src/util/type';
+import { UserSocketStorage } from '../src/user-status/user-socket.storage';
+import { Users } from '../src/entity/users.entity';
+import { generateUsers } from './generate-mock-data';
+import { nanoid } from 'nanoid';
+import { timeout } from './util';
+
+const URL = 'http://localhost:4247';
+
+describe('GameGateway (e2e)', () => {
+  let app: INestApplication;
+  let clientSockets: Socket[];
+  let gateway: GameGateway;
+  let usersEntities: Users[];
+  let userIds: UserId[];
+  let userSocketStorage: UserSocketStorage;
+  let index = 0;
+
+  beforeAll(async () => {
+    usersEntities = generateUsers(30);
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    await app.listen(4247);
+    gateway = app.get(GameGateway);
+    userSocketStorage = app.get(UserSocketStorage);
+  });
+
+  beforeEach(async () => {
+    userIds = [
+      usersEntities[index++].userId,
+      usersEntities[index++].userId,
+      usersEntities[index++].userId,
+    ];
+    clientSockets = userIds.map((userId) =>
+      io(URL, { extraHeaders: { 'x-user-id': userId.toString() } }),
+    );
+    await Promise.all(
+      clientSockets.map(
+        (socket) =>
+          new Promise((resolve) => socket.on('connect', () => resolve('done'))),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    clientSockets.forEach((socket) => socket.disconnect());
+  });
+
+  afterAll(async () => await app.close());
+
+  describe('newGame', () => {
+    it('should notify both users when a new game is matched (ladder)', async () => {
+      const [playerOne, playerTwo] = clientSockets;
+      const gameId = nanoid();
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[0]),
+        `game-${gameId}`,
+      );
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[1]),
+        `game-${gameId}`,
+      );
+      const [wsMessageOne, wsMessageTwo] = await Promise.all([
+        new Promise((resolve) =>
+          playerOne.on('newGame', (data) => resolve(data)),
+        ),
+        new Promise((resolve) =>
+          playerTwo.on('newGame', (data) => resolve(data)),
+        ),
+        gateway.emitNewGame(`game-${gameId}`, gameId),
+      ]);
+      expect(wsMessageOne).toEqual({ gameId });
+      expect(wsMessageTwo).toEqual({ gameId });
+    });
+
+    it('should notify only the invited when a user invites another user to a game (normal)', async () => {
+      const [playerOne, playerTwo] = clientSockets;
+      const gameId = nanoid();
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[0]),
+        `game-${gameId}`,
+      );
+      const [wsMessageOne, wsError] = await Promise.allSettled([
+        new Promise((resolve) =>
+          playerOne.on('newGame', (data) => resolve(data)),
+        ),
+        timeout(
+          1000,
+          new Promise((resolve) =>
+            playerTwo.on('newGame', (data) => resolve(data)),
+          ),
+        ),
+        gateway.emitNewGame(`game-${gameId}`, gameId),
+      ]);
+      if (wsMessageOne.status === 'rejected') {
+        fail();
+      }
+      expect(wsMessageOne.value).toEqual({ gameId });
+      expect(wsError.status).toEqual('rejected');
+    });
+  });
+
+  // describe('gameStarted', () => {
+  //   it('should notify all players that are at /waiting-room UI that a new game has been started', async () => {});
+  // });
+
+  describe('gameOption', () => {
+    it('should notify the invited that the game option has been changed', async () => {
+      const [playerOne] = clientSockets;
+      const gameId = nanoid();
+      gateway.joinRoom(
+        userSocketStorage.clients.get(userIds[0]),
+        `game-${gameId}`,
+      );
+      const [wsMessageOne] = await Promise.all([
+        new Promise((resolve) =>
+          playerOne.on('gameOption', (data) => resolve(data)),
+        ),
+        gateway.emitGameOption(`game-${gameId}`, 3),
+      ]);
+      expect(wsMessageOne).toEqual({ map: 3 });
+    });
+  });
+
+  // TODO : 추후에 클라이언트에서 라이브로 전달되어야하는 데이터가 파악되면 구현
+  // describe('gameStatus', () => {
+  //   it('should notify both players of the games current status', async () => {
+  //     const [playerOne, playerTwo] = clientSockets;
+  //     const gameId = nanoid();
+  //     gateway.joinRoom(
+  //       userSocketStorage.clients.get(userIds[0]),
+  //       `game-${gameId}`,
+  //     );
+  //     gateway.joinRoom(
+  //       userSocketStorage.clients.get(userIds[1]),
+  //       `game-${gameId}`,
+  //     );
+  //     const [wsMessageOne, wsMessageTwo] = await Promise.all([
+  //       new Promise((resolve) =>
+  //         playerOne.on('gameStatus', (data) => resolve(data)),
+  //       ),
+  //       new Promise((resolve) =>
+  //         playerTwo.on('gameStatus', (data) => resolve(data)),
+  //       ),
+  //       gateway.emitGameStatus(`game-${gameId}`, 'started'),
+  //     ]);
+  //     expect(wsMessageOne).toEqual({ status: 'started' });
+  //     expect(wsMessageTwo).toEqual({ status: 'started' });
+  //   });
+  // });
+});


### PR DESCRIPTION
## 개요
- #100 진행 중
- #101 진행 중
- 뜻밖의 #105 가 발견됐고, 너무 커질 것 같아 중간에 PR 한번 합니다.
- 게임 설계에 허점이 많았어서 구현하며 동적 설계를 병행하고 있습니다. 동의하지 않는 설계/구현이 보이시면 말씀해주세요 :)

## 작업 사항
- 게임 매칭되면 매칭된 유저에게 gameId 전달해주며 알리는 `newGame` emitter 구현.
- 게임 옵션 설정 relay 하는 `gameOption` emitter 구현.
- 새 게임 시작을 waitingRoom UI 에 있는 유저들에게 알리는 `gameStarted` emitter 구현.
- 게임 정상 종료 시 클라이언트가 보내는 `gameComplete` 이벤트 listner 구현.
- 게임 종료 후 결과 DB 에 업데이트 하는 `GameService.updateResult` 구현.
- #105 임시 처리. 일단 문제가 생기는 곳에서 undefined 체크 해주는데, 이게 충분할지... 내일 클러스터 오시면 같이 이야기해보죠 @yongjulejule.

## 변경점
- UserStatusModule 에서 ChatsGateway 를 provider 로 받고 있었습니다. 이렇게 되면 ChatsGateway 가 두 모듈에서 provider 로 불리기 때문에 두번 인스턴스화 됩니다(어떻게 알았는지 물으신다면 저도 알고싶지 않았습니다...이벤트를 두번씩 listen...). 따라서 UserStatusModule 에 ChatsModule 을 모듈로 import 받도록 설정했습니다. Circular dependency 를 해결하기 위해 양 모듈에서 `forwardRef` 를 활용했습니다.