### PR TITLE
✨ feat : ranks 변화를 알리는 RanksGateway 구현

### DIFF
--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -4,12 +4,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { GameGateway } from './game.gateway';
 import { GameStorage } from './game.storage';
 import { MatchHistory } from '../entity/match-history.entity';
+import { RanksModule } from '../ranks/ranks.module';
 import { UserStatusModule } from '../user-status/user-status.module';
 import { Users } from '../entity/users.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([MatchHistory, Users]),
+    RanksModule,
     forwardRef(() => UserStatusModule),
   ],
   providers: [GameGateway, GameStorage],

--- a/backend/src/ranks/dto/ranks-gateway.dto.ts
+++ b/backend/src/ranks/dto/ranks-gateway.dto.ts
@@ -1,0 +1,6 @@
+import { UserId } from '../../util/type';
+
+export interface LadderUpdateDto {
+  winnerId: UserId;
+  ladder: number;
+}

--- a/backend/src/ranks/ranks.gateway.ts
+++ b/backend/src/ranks/ranks.gateway.ts
@@ -1,0 +1,48 @@
+import { Server } from 'socket.io';
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+
+import { LadderUpdateDto } from './dto/ranks-gateway.dto';
+import { SocketId } from '../util/type';
+
+@WebSocketGateway()
+export class RanksGateway {
+  @WebSocketServer()
+  private readonly server: Server;
+
+  /**
+   * @description 유저가 랭킹 UI를 보기 시작할 때, ranks room 입장
+   *
+   * @param socketId socket id
+   */
+  joinRanksRoom(socketId: SocketId) {
+    this.server.in(socketId).socketsJoin('ranks');
+  }
+
+  /**
+   * @description 랭킹 UI 보고 있던 유저가 랭킹 UI를 떠날 때, ranks room 퇴장
+   *
+   * @param socketId socket id
+   */
+  leaveRanksRoom(socketId: SocketId) {
+    this.server.in(socketId).socketsLeave('ranks');
+  }
+
+  /**
+   * @description 게임 종료 시, 랭킹 업데이트 이벤트 ranks UI 보고 있는 유저들에게 전송
+   *
+   * @param ladderUpdate 랭킹 업데이트 정보
+   */
+  emitLadderUpdate(ladderUpdate: LadderUpdateDto) {
+    this.server.to('ranks').emit('ladderUpdate', ladderUpdate);
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * NOTE : TEST ONLY                                                          *
+   *                                                                           *
+   ****************************************************************************/
+
+  doesRanksRoomExist() {
+    return this.server.sockets.adapter.rooms.get('ranks') !== undefined;
+  }
+}

--- a/backend/src/ranks/ranks.module.ts
+++ b/backend/src/ranks/ranks.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { RanksGateway } from './ranks.gateway';
+
+@Module({
+  providers: [RanksGateway],
+  exports: [RanksGateway],
+})
+export class RanksModule {}

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -23,7 +23,7 @@ import { ChannelStorage } from './channel.storage';
 import { ChatsGateway } from '../chats/chats.gateway';
 import { CurrentUiDto } from './dto/user-status.dto';
 import { GameGateway } from '../game/game.gateway';
-import { GameStorage } from '../game/game.storage';
+import { RanksGateway } from '../ranks/ranks.gateway';
 import { UserActivityDto } from './dto/user-status.dto';
 import { UserRelationshipStorage } from './user-relationship.storage';
 import { UserSocketStorage } from './user-socket.storage';
@@ -47,7 +47,7 @@ export class ActivityGateway
     private readonly channelStorage: ChannelStorage,
     private readonly chatsGateway: ChatsGateway,
     private readonly gameGateway: GameGateway,
-    private readonly gameStorage: GameStorage,
+    private readonly ranksGateway: RanksGateway,
     private readonly userRelationshipStorage: UserRelationshipStorage,
     private readonly userSocketStorage: UserSocketStorage,
   ) {}
@@ -196,8 +196,12 @@ export class ActivityGateway
       );
     } else if (prevUi === 'chats') {
       this.chatsGateway.leaveRoom(socketId, prevUi);
+    } else if (prevUi === 'waitingRoom') {
+      this.gameGateway.leaveRoom(socketId, 'waitingRoom');
     } else if (prevUi.startsWith('game-')) {
       this.gameGateway.abortIfPlayerLeave(prevUi.replace('game-', ''), userId);
+    } else if (prevUi === 'ranks') {
+      this.ranksGateway.leaveRanksRoom(socketId);
     }
   }
 
@@ -230,6 +234,8 @@ export class ActivityGateway
        * GameService & controller 구현하면서 확인하기
        */
       this.gameGateway.joinRoom(socketId, ui as `game-${GameId}`);
+    } else if (ui === 'ranks') {
+      this.ranksGateway.joinRanksRoom(socketId);
     }
   }
 }

--- a/backend/src/user-status/user-status.module.ts
+++ b/backend/src/user-status/user-status.module.ts
@@ -13,6 +13,7 @@ import { Friends } from '../entity/friends.entity';
 import { GameModule } from '../game/game.module';
 import { MatchHistory } from '../entity/match-history.entity';
 import { Messages } from '../entity/messages.entity';
+import { RanksModule } from '../ranks/ranks.module';
 import { UserRelationshipStorage } from './user-relationship.storage';
 import { UserSocketStorage } from './user-socket.storage';
 import { Users } from '../entity/users.entity';
@@ -31,6 +32,7 @@ import { Users } from '../entity/users.entity';
     ]),
     forwardRef(() => ChatsModule),
     forwardRef(() => GameModule),
+    RanksModule,
   ],
   providers: [
     ActivityGateway,

--- a/backend/test/game-gateway.e2e-spec.ts
+++ b/backend/test/game-gateway.e2e-spec.ts
@@ -26,8 +26,8 @@ import {
 } from './db-resource-manager';
 import { UserSocketStorage } from '../src/user-status/user-socket.storage';
 import { Users } from '../src/entity/users.entity';
+import { calculateLadderRise, listenPromise, timeout } from './util';
 import { generateUsers } from './generate-mock-data';
-import { timeout } from './util';
 
 const URL = 'http://localhost:4247';
 
@@ -418,7 +418,6 @@ describe('GameGateway (e2e)', () => {
         prevWinner.ladder,
         prevLoser.ladder,
         scores,
-        prevWinner.ladder >= prevLoser.ladder,
       );
       expect(postGame.length).toBe(2);
       expect(postWinner).toMatchObject({
@@ -477,7 +476,6 @@ describe('GameGateway (e2e)', () => {
         prevWinner.ladder,
         prevLoser.ladder,
         scores,
-        prevWinner.ladder >= prevLoser.ladder,
       );
       expect(postGame.length).toBe(2);
       expect(postWinner).toMatchObject({
@@ -628,7 +626,6 @@ describe('GameGateway (e2e)', () => {
         prevWinner.ladder,
         prevLoser.ladder,
         [5, 0],
-        prevWinner.ladder >= prevLoser.ladder,
       );
       expect(postWinner).toMatchObject({
         winCount: prevWinner.winCount + 1,
@@ -700,7 +697,6 @@ describe('GameGateway (e2e)', () => {
         prevWinner.ladder,
         prevLoser.ladder,
         [0, 5],
-        prevWinner.ladder >= prevLoser.ladder,
       );
       expect(postWinner).toMatchObject({
         winCount: prevWinner.winCount + 1,
@@ -916,19 +912,6 @@ describe('GameGateway (e2e)', () => {
    *                                                                           *
    ****************************************************************************/
 
-  const calculateLadderRise = (
-    winnerLadder: number,
-    loserLadder: number,
-    scores: number[],
-    isHigher: boolean,
-  ) => {
-    const ladderGap = Math.abs(winnerLadder - loserLadder);
-    const scoreGap = Math.abs(scores[0] - scores[1]);
-    return isHigher
-      ? Math.max(Math.floor(scoreGap * (1 - ladderGap / 42)), 1)
-      : Math.floor(scoreGap * (1 + ladderGap / 42));
-  };
-
   const winnerLoserStats = (
     prevGame: Users[],
     postGame: Users[],
@@ -944,9 +927,6 @@ describe('GameGateway (e2e)', () => {
         : [postGame[1], postGame[0]];
     return { prevWinner, prevLoser, postWinner, postLoser };
   };
-
-  const listenPromise = (socket: Socket, event: string) =>
-    new Promise((resolve) => socket.on(event, resolve));
 });
 
 // TODO : 추후에 클라이언트에서 라이브로 전달되어야하는 데이터가 파악되면 구현

--- a/backend/test/ranks.e2e-spec.ts
+++ b/backend/test/ranks.e2e-spec.ts
@@ -1,0 +1,345 @@
+import { DataSource, In } from 'typeorm';
+import { INestApplication } from '@nestjs/common';
+import { Socket, io } from 'socket.io-client';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { nanoid } from 'nanoid';
+import waitForExpect from 'wait-for-expect';
+
+import { ActivityManager } from '../src/user-status/activity.manager';
+import { AppModule } from '../src/app.module';
+import { GameInfo, UserId } from '../src/util/type';
+import { GameStorage } from '../src/game/game.storage';
+import { RanksGateway } from '../src/ranks/ranks.gateway';
+import {
+  TYPEORM_SHARED_CONFIG,
+  createDataSources,
+  destroyDataSources,
+} from './db-resource-manager';
+import { Users } from '../src/entity/users.entity';
+import { calculateLadderRise, listenPromise, timeout } from './util';
+import { generateUsers } from './generate-mock-data';
+
+const PORT = 4246;
+const URL = `http://localhost:${PORT}`;
+
+const TEST_DB = 'test_db_ranks_gateway';
+const ENTITIES = [Users];
+
+process.env.NODE_ENV = 'development';
+
+describe('GameGateway (e2e)', () => {
+  let app: INestApplication;
+  let clientSockets: Socket[];
+  let dataSource: DataSource;
+  let initDataSource: DataSource;
+  let activityManager: ActivityManager;
+  let gateway: RanksGateway;
+  let gameStorage: GameStorage;
+  let usersEntities: Users[];
+  let users: Users[];
+  let userIds: UserId[];
+  let index = 0;
+
+  beforeAll(async () => {
+    const dataSources = await createDataSources(TEST_DB, ENTITIES);
+    initDataSource = dataSources.initDataSource;
+    dataSource = dataSources.dataSource;
+    usersEntities = generateUsers(48);
+    await dataSource.manager.save(usersEntities);
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          ...TYPEORM_SHARED_CONFIG,
+          autoLoadEntities: true,
+          database: TEST_DB,
+        }),
+        AppModule,
+      ],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    await app.listen(PORT);
+    gateway = app.get(RanksGateway);
+    activityManager = app.get(ActivityManager);
+    gameStorage = app.get(GameStorage);
+  });
+
+  beforeEach(async () => {
+    users = [
+      usersEntities[index++],
+      usersEntities[index++],
+      usersEntities[index++],
+      usersEntities[index++],
+      usersEntities[index++],
+      usersEntities[index++],
+    ];
+    userIds = users.map(({ userId }) => userId);
+    clientSockets = userIds.map((userId) =>
+      io(URL, { extraHeaders: { 'x-user-id': userId.toString() } }),
+    );
+    await Promise.all(
+      clientSockets.map(
+        (socket) =>
+          new Promise((resolve) => socket.on('connect', () => resolve('done'))),
+      ),
+    );
+  });
+
+  afterEach(() => clientSockets.forEach((socket) => socket.disconnect()));
+
+  afterAll(async () => {
+    await app.close();
+    await destroyDataSources(TEST_DB, dataSource, initDataSource);
+  });
+
+  describe('joinRanksRoom & leaveRanksRoom', () => {
+    it('should join the ranks room when the user navigates to the ranks UI', async () => {
+      const [userOne] = clientSockets;
+      userOne.emit('currentUi', { userId: userIds[0], ui: 'ranks' });
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(userIds[0])).toBe('ranks');
+        expect(gateway.doesRanksRoomExist()).toBeTruthy();
+      });
+    });
+
+    it('should leave the ranks room when the user leaves the ranks UI', async () => {
+      const [userOne] = clientSockets;
+      userOne.emit('currentUi', { userId: userIds[0], ui: 'ranks' });
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(userIds[0])).toBe('ranks');
+        expect(gateway.doesRanksRoomExist()).toBeTruthy();
+      });
+      userOne.emit('currentUi', { userId: userIds[0], ui: 'profile' });
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(userIds[0])).toBe('profile');
+        expect(gateway.doesRanksRoomExist()).toBeFalsy();
+      });
+    });
+  });
+
+  describe('ladderUpdate', () => {
+    it('should not notify the users in the ranks UI when a player wins a non-ladder game', async () => {
+      const gameId = nanoid();
+      gameStorage.games.set(gameId, new GameInfo(users[0], users[1], 1, false));
+      const [playerOne, playerTwo, ranksOne, ranksTwo, profile, waitingRoom] =
+        clientSockets;
+      playerOne.emit('currentUi', { userId: userIds[0], ui: `game-${gameId}` });
+      playerTwo.emit('currentUi', { userId: userIds[1], ui: `game-${gameId}` });
+      ranksOne.emit('currentUi', { userId: userIds[2], ui: 'ranks' });
+      ranksTwo.emit('currentUi', { userId: userIds[3], ui: 'ranks' });
+      profile.emit('currentUi', { userId: userIds[4], ui: 'profile' });
+      waitingRoom.emit('currentUi', { userId: userIds[5], ui: 'waitingRoom' });
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(userIds[0])).toBe(`game-${gameId}`);
+        expect(activityManager.getActivity(userIds[1])).toBe(`game-${gameId}`);
+        expect(activityManager.getActivity(userIds[2])).toBe('ranks');
+        expect(activityManager.getActivity(userIds[3])).toBe('ranks');
+        expect(activityManager.getActivity(userIds[4])).toBe('profile');
+        expect(activityManager.getActivity(userIds[5])).toBe('waitingRoom');
+      });
+      const [
+        playerFailOne,
+        playerFailTwo,
+        profileFail,
+        waitingRoomFail,
+        ranksFailOne,
+        ranksFailTwo,
+      ] = await Promise.allSettled([
+        timeout(1000, listenPromise(playerOne, 'ladderUpdate')),
+        timeout(1000, listenPromise(playerTwo, 'ladderUpdate')),
+        timeout(1000, listenPromise(profile, 'ladderUpdate')),
+        timeout(1000, listenPromise(waitingRoom, 'ladderUpdate')),
+        timeout(1000, listenPromise(ranksOne, 'ladderUpdate')),
+        timeout(1000, listenPromise(ranksTwo, 'ladderUpdate')),
+        playerOne.emit('gameComplete', { id: gameId, scores: [5, 1] }),
+      ]);
+      expect(playerFailOne.status).toBe('rejected');
+      expect(playerFailTwo.status).toBe('rejected');
+      expect(profileFail.status).toBe('rejected');
+      expect(waitingRoomFail.status).toBe('rejected');
+      expect(ranksFailOne.status).toBe('rejected');
+      expect(ranksFailTwo.status).toBe('rejected');
+    });
+
+    it('should not notify the users in the ranks UI when a player aborts a non-ladder game', async () => {
+      const gameId = nanoid();
+      gameStorage.games.set(gameId, new GameInfo(users[0], users[1], 1, false));
+      const [playerOne, playerTwo, ranksOne, ranksTwo, profile, waitingRoom] =
+        clientSockets;
+      playerOne.emit('currentUi', { userId: userIds[0], ui: `game-${gameId}` });
+      playerTwo.emit('currentUi', { userId: userIds[1], ui: `game-${gameId}` });
+      ranksOne.emit('currentUi', { userId: userIds[2], ui: 'ranks' });
+      ranksTwo.emit('currentUi', { userId: userIds[3], ui: 'ranks' });
+      profile.emit('currentUi', { userId: userIds[4], ui: 'profile' });
+      waitingRoom.emit('currentUi', { userId: userIds[5], ui: 'waitingRoom' });
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(userIds[0])).toBe(`game-${gameId}`);
+        expect(activityManager.getActivity(userIds[1])).toBe(`game-${gameId}`);
+        expect(activityManager.getActivity(userIds[2])).toBe('ranks');
+        expect(activityManager.getActivity(userIds[3])).toBe('ranks');
+        expect(activityManager.getActivity(userIds[4])).toBe('profile');
+        expect(activityManager.getActivity(userIds[5])).toBe('waitingRoom');
+      });
+      const [
+        playerFailOne,
+        playerFailTwo,
+        profileFail,
+        waitingRoomFail,
+        ranksFailOne,
+        ranksFailTwo,
+      ] = await Promise.allSettled([
+        timeout(1000, listenPromise(playerOne, 'ladderUpdate')),
+        timeout(1000, listenPromise(playerTwo, 'ladderUpdate')),
+        timeout(1000, listenPromise(profile, 'ladderUpdate')),
+        timeout(1000, listenPromise(waitingRoom, 'ladderUpdate')),
+        timeout(1000, listenPromise(ranksOne, 'ladderUpdate')),
+        timeout(1000, listenPromise(ranksTwo, 'ladderUpdate')),
+        playerOne.emit('gameComplete', { id: gameId, scores: [5, 1] }),
+      ]);
+      expect(playerFailOne.status).toBe('rejected');
+      expect(playerFailTwo.status).toBe('rejected');
+      expect(profileFail.status).toBe('rejected');
+      expect(waitingRoomFail.status).toBe('rejected');
+      expect(ranksFailOne.status).toBe('rejected');
+      expect(ranksFailTwo.status).toBe('rejected');
+    });
+
+    it('should notify the users in the ranks UI when a player wins a ladder game', async () => {
+      const prevGame = await dataSource.manager.find(Users, {
+        select: ['userId', 'winCount', 'lossCount', 'ladder'],
+        where: { userId: In([userIds[0], userIds[1]]) },
+      });
+      expect(prevGame.length).toBe(2);
+      const gameId = nanoid();
+      gameStorage.games.set(gameId, new GameInfo(users[0], users[1], 1, true));
+      const [playerOne, playerTwo, ranksOne, ranksTwo, profile, waitingRoom] =
+        clientSockets;
+      playerOne.emit('currentUi', { userId: userIds[0], ui: `game-${gameId}` });
+      playerTwo.emit('currentUi', { userId: userIds[1], ui: `game-${gameId}` });
+      ranksOne.emit('currentUi', { userId: userIds[2], ui: 'ranks' });
+      ranksTwo.emit('currentUi', { userId: userIds[3], ui: 'ranks' });
+      profile.emit('currentUi', { userId: userIds[4], ui: 'profile' });
+      waitingRoom.emit('currentUi', { userId: userIds[5], ui: 'waitingRoom' });
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(userIds[0])).toBe(`game-${gameId}`);
+        expect(activityManager.getActivity(userIds[1])).toBe(`game-${gameId}`);
+        expect(activityManager.getActivity(userIds[2])).toBe('ranks');
+        expect(activityManager.getActivity(userIds[3])).toBe('ranks');
+        expect(activityManager.getActivity(userIds[4])).toBe('profile');
+        expect(activityManager.getActivity(userIds[5])).toBe('waitingRoom');
+      });
+      const [
+        playerFailOne,
+        playerFailTwo,
+        profileFail,
+        waitingRoomFail,
+        ranksSuccessOne,
+        ranksSuccessTwo,
+      ] = await Promise.allSettled([
+        timeout(1000, listenPromise(playerOne, 'ladderUpdate')),
+        timeout(1000, listenPromise(playerTwo, 'ladderUpdate')),
+        timeout(1000, listenPromise(profile, 'ladderUpdate')),
+        timeout(1000, listenPromise(waitingRoom, 'ladderUpdate')),
+        listenPromise(ranksOne, 'ladderUpdate'),
+        listenPromise(ranksTwo, 'ladderUpdate'),
+        playerOne.emit('gameComplete', { id: gameId, scores: [5, 1] }),
+      ]);
+      expect(playerFailOne.status).toBe('rejected');
+      expect(playerFailTwo.status).toBe('rejected');
+      expect(profileFail.status).toBe('rejected');
+      expect(waitingRoomFail.status).toBe('rejected');
+      if (
+        ranksSuccessOne.status === 'rejected' ||
+        ranksSuccessTwo.status === 'rejected'
+      ) {
+        fail();
+      }
+      const [prevWinner, prevLoser] =
+        prevGame[0].userId === userIds[0]
+          ? [prevGame[0], prevGame[1]]
+          : [prevGame[1], prevGame[0]];
+      expect(ranksSuccessOne.value).toEqual({
+        winnerId: userIds[0],
+        ladder:
+          prevWinner.ladder +
+          calculateLadderRise(prevWinner.ladder, prevLoser.ladder, [5, 1]),
+      });
+      expect(ranksSuccessTwo.value).toEqual({
+        winnerId: userIds[0],
+        ladder:
+          prevWinner.ladder +
+          calculateLadderRise(prevWinner.ladder, prevLoser.ladder, [5, 1]),
+      });
+    });
+
+    it('should notify the users in the ranks UI when a player aborts a ladder game', async () => {
+      const prevGame = await dataSource.manager.find(Users, {
+        select: ['userId', 'winCount', 'lossCount', 'ladder'],
+        where: { userId: In([userIds[0], userIds[1]]) },
+      });
+      expect(prevGame.length).toBe(2);
+      const gameId = nanoid();
+      gameStorage.games.set(gameId, new GameInfo(users[0], users[1], 1, true));
+      const [playerOne, playerTwo, ranksOne, ranksTwo, profile, waitingRoom] =
+        clientSockets;
+      playerOne.emit('currentUi', { userId: userIds[0], ui: `game-${gameId}` });
+      playerTwo.emit('currentUi', { userId: userIds[1], ui: `game-${gameId}` });
+      ranksOne.emit('currentUi', { userId: userIds[2], ui: 'ranks' });
+      ranksTwo.emit('currentUi', { userId: userIds[3], ui: 'ranks' });
+      profile.emit('currentUi', { userId: userIds[4], ui: 'profile' });
+      waitingRoom.emit('currentUi', { userId: userIds[5], ui: 'waitingRoom' });
+      await waitForExpect(() => {
+        expect(activityManager.getActivity(userIds[0])).toBe(`game-${gameId}`);
+        expect(activityManager.getActivity(userIds[1])).toBe(`game-${gameId}`);
+        expect(activityManager.getActivity(userIds[2])).toBe('ranks');
+        expect(activityManager.getActivity(userIds[3])).toBe('ranks');
+        expect(activityManager.getActivity(userIds[4])).toBe('profile');
+        expect(activityManager.getActivity(userIds[5])).toBe('waitingRoom');
+      });
+      const [
+        playerFailOne,
+        playerFailTwo,
+        profileFail,
+        waitingRoomFail,
+        ranksSuccessOne,
+        ranksSuccessTwo,
+      ] = await Promise.allSettled([
+        timeout(1000, listenPromise(playerOne, 'ladderUpdate')),
+        timeout(1000, listenPromise(playerTwo, 'ladderUpdate')),
+        timeout(1000, listenPromise(profile, 'ladderUpdate')),
+        timeout(1000, listenPromise(waitingRoom, 'ladderUpdate')),
+        listenPromise(ranksOne, 'ladderUpdate'),
+        listenPromise(ranksTwo, 'ladderUpdate'),
+        playerOne.disconnect(),
+      ]);
+      expect(playerFailOne.status).toBe('rejected');
+      expect(playerFailTwo.status).toBe('rejected');
+      expect(profileFail.status).toBe('rejected');
+      expect(waitingRoomFail.status).toBe('rejected');
+      if (
+        ranksSuccessOne.status === 'rejected' ||
+        ranksSuccessTwo.status === 'rejected'
+      ) {
+        fail();
+      }
+      const [prevWinner, prevLoser] =
+        prevGame[0].userId === userIds[1]
+          ? [prevGame[0], prevGame[1]]
+          : [prevGame[1], prevGame[0]];
+      expect(ranksSuccessOne.value).toEqual({
+        winnerId: userIds[1],
+        ladder:
+          prevWinner.ladder +
+          calculateLadderRise(prevWinner.ladder, prevLoser.ladder, [0, 5]),
+      });
+      expect(ranksSuccessTwo.value).toEqual({
+        winnerId: userIds[1],
+        ladder:
+          prevWinner.ladder +
+          calculateLadderRise(prevWinner.ladder, prevLoser.ladder, [0, 5]),
+      });
+    });
+  });
+});

--- a/backend/test/util.ts
+++ b/backend/test/util.ts
@@ -1,3 +1,5 @@
+import { Socket } from 'socket.io-client';
+
 export async function timeout<T>(ms: number, promise: Promise<T>): Promise<T> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -15,3 +17,18 @@ export async function timeout<T>(ms: number, promise: Promise<T>): Promise<T> {
     );
   });
 }
+
+export const listenPromise = (socket: Socket, event: string) =>
+  new Promise((resolve) => socket.on(event, resolve));
+
+export const calculateLadderRise = (
+  winnerLadder: number,
+  loserLadder: number,
+  scores: number[],
+) => {
+  const ladderGap = Math.abs(winnerLadder - loserLadder);
+  const scoreGap = Math.abs(scores[0] - scores[1]);
+  return winnerLadder >= loserLadder
+    ? Math.max(Math.floor(scoreGap * (1 - ladderGap / 42)), 1)
+    : Math.floor(scoreGap * (1 + ladderGap / 42));
+};


### PR DESCRIPTION
## 개요
- #116  완료

## 작업 사항
- 게임 결과 업데이트 후, ranks UI 에 있는 유저들에게 승자와 승자의 새로운 ladder 를 알려주는 `ladderUpdate` emitter 구현.
- ranks 관련 방 관리.

## 변경점
- GameGateway 방관리 테스트가 없어서 추가해줬습니다.

close #116