### PR TITLE
✨ feat : 유저 랭킹 반환하는 RanksService 구현

### DIFF
--- a/backend/src/ranks/dto/ranks.dto.ts
+++ b/backend/src/ranks/dto/ranks.dto.ts
@@ -6,8 +6,9 @@ export interface MyRankDto {
 }
 
 interface RankElement {
-  userId: UserId;
+  id: UserId;
   ladder: number;
+  rank: number;
 }
 
 export interface RanksDto {

--- a/backend/src/ranks/dto/ranks.dto.ts
+++ b/backend/src/ranks/dto/ranks.dto.ts
@@ -1,0 +1,15 @@
+import { UserId } from '../../util/type';
+
+export interface MyRankDto {
+  myRank: number;
+  totol: number;
+}
+
+interface RankElement {
+  userId: UserId;
+  ladder: number;
+}
+
+export interface RanksDto {
+  users: RankElement[];
+}

--- a/backend/src/ranks/ranks.module.ts
+++ b/backend/src/ranks/ranks.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { RanksGateway } from './ranks.gateway';
+import { RanksService } from './ranks.service';
 
 @Module({
-  providers: [RanksGateway],
+  providers: [RanksGateway, RanksService],
   exports: [RanksGateway],
 })
 export class RanksModule {}

--- a/backend/src/ranks/ranks.service.spec.ts
+++ b/backend/src/ranks/ranks.service.spec.ts
@@ -1,0 +1,78 @@
+import { DataSource } from 'typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { faker } from '@faker-js/faker';
+
+import { RanksService } from './ranks.service';
+import {
+  TYPEORM_SHARED_CONFIG,
+  createDataSources,
+  destroyDataSources,
+} from '../../test/db-resource-manager';
+import { Users } from '../entity/users.entity';
+import { generateUsers } from '../../test/generate-mock-data';
+
+const TEST_DB = 'test_db_ranks_service';
+const ENTITIES = [Users];
+
+describe('RanksService', () => {
+  let service: RanksService;
+  let dataSource: DataSource;
+  let initDataSource: DataSource;
+  let usersEntities: Users[];
+  const length = faker.datatype.number({ min: 500, max: 1000 });
+  const rankMap: Map<number, number> = new Map();
+
+  beforeAll(async () => {
+    const dataSources = await createDataSources(TEST_DB, ENTITIES);
+    initDataSource = dataSources.initDataSource;
+    dataSource = dataSources.dataSource;
+    usersEntities = generateUsers(length).sort(
+      (a: Users, b: Users) => b.ladder - a.ladder,
+    );
+    let currentLadder = Number.MAX_SAFE_INTEGER;
+    let position = 1;
+    usersEntities.forEach((user: Users) => {
+      if (currentLadder > user.ladder) {
+        currentLadder = user.ladder;
+        rankMap.set(user.ladder, position);
+        position++;
+      }
+    });
+    await dataSource.getRepository(Users).insert(usersEntities);
+  });
+
+  afterAll(() => destroyDataSources(TEST_DB, dataSource, initDataSource));
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          ...TYPEORM_SHARED_CONFIG,
+          autoLoadEntities: true,
+          database: TEST_DB,
+        }),
+        TypeOrmModule.forFeature([Users]),
+      ],
+      providers: [RanksService],
+    }).compile();
+
+    service = module.get<RanksService>(RanksService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it("should return the requester's rank and a total number of players", async () => {
+    const { userId, ladder } =
+      usersEntities[Math.floor(Math.random() * length)];
+    expect(await service.findPosition(userId)).toEqual({
+      myRank: rankMap.get(ladder),
+      total: usersEntities.length,
+    });
+  });
+
+  // it('should return ids and ladders of a range of users, ordered by their ladders', async () => {});
+});

--- a/backend/src/ranks/ranks.service.spec.ts
+++ b/backend/src/ranks/ranks.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { faker } from '@faker-js/faker';
 
+import { RanksDto } from './dto/ranks.dto';
 import { RanksService } from './ranks.service';
 import {
   TYPEORM_SHARED_CONFIG,
@@ -52,12 +53,12 @@ describe('RanksService', () => {
           ...TYPEORM_SHARED_CONFIG,
           autoLoadEntities: true,
           database: TEST_DB,
+          logging: true,
         }),
         TypeOrmModule.forFeature([Users]),
       ],
       providers: [RanksService],
     }).compile();
-
     service = module.get<RanksService>(RanksService);
   });
 
@@ -74,5 +75,21 @@ describe('RanksService', () => {
     });
   });
 
-  // it('should return ids and ladders of a range of users, ordered by their ladders', async () => {});
+  it('should return ids and ladders of a range of users, ordered by their ladders', async () => {
+    let ranksDto: RanksDto = await service.findLadders(0, 20);
+    expect(ranksDto.users.length).toEqual(20);
+    let ladders = ranksDto.users.map(({ ladder }) => ladder);
+    expect(ladders).toEqual(
+      usersEntities.slice(0, 20).map(({ ladder }) => ladder),
+    );
+    ranksDto = await service.findLadders(30, 42);
+    expect(ranksDto.users.length).toEqual(42);
+    ladders = ranksDto.users.map(({ ladder }) => ladder);
+    expect(ladders).toEqual(
+      expect.arrayContaining(
+        usersEntities.slice(30, 72).map(({ ladder }) => ladder),
+      ),
+    );
+    expect((await service.findLadders(0, 10000)).users.length).toEqual(length);
+  });
 });

--- a/backend/src/ranks/ranks.service.spec.ts
+++ b/backend/src/ranks/ranks.service.spec.ts
@@ -53,7 +53,6 @@ describe('RanksService', () => {
           ...TYPEORM_SHARED_CONFIG,
           autoLoadEntities: true,
           database: TEST_DB,
-          logging: true,
         }),
         TypeOrmModule.forFeature([Users]),
       ],

--- a/backend/src/ranks/ranks.service.ts
+++ b/backend/src/ranks/ranks.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   InternalServerErrorException,
   Logger,
+  NotFoundException,
 } from '@nestjs/common';
 import { Repository } from 'typeorm';
 
@@ -12,6 +13,11 @@ import { Users } from '../entity/users.entity';
 @Injectable()
 export class RanksService {
   private readonly logger = new Logger(RanksService.name);
+  private readonly ranksCte = this.usersRepository
+    .createQueryBuilder()
+    .select('user_id')
+    .addSelect('ladder')
+    .addSelect('RANK() OVER (ORDER BY ladder DESC)::INTEGER', 'rank');
 
   constructor(
     @InjectRepository(Users)
@@ -28,19 +34,28 @@ export class RanksService {
    */
   async findLadders(offset: number, limit: number) {
     try {
-      return {
-        users: await this.usersRepository.find({
-          select: ['userId', 'ladder'],
-          order: { ladder: 'DESC' },
-          skip: offset,
-          take: limit,
-        }),
-      };
+      const users = await this.usersRepository.manager
+        .createQueryBuilder()
+        .addCommonTableExpression(this.ranksCte, 'Ranks')
+        .select('user_id', 'id')
+        .addSelect('ladder')
+        .addSelect('rank')
+        .from('Ranks', 'Ranks')
+        .orderBy('rank')
+        .offset(offset)
+        .limit(limit)
+        .getRawMany();
+      if (users.length === 0) {
+        throw new NotFoundException(`No users from offset=${offset}`);
+      }
+      return { users };
     } catch (e) {
       this.logger.error(e);
-      throw new InternalServerErrorException(
-        `Failed to find ladders of ${limit} users from offset=${offset}`,
-      );
+      throw e instanceof NotFoundException
+        ? e
+        : new InternalServerErrorException(
+            `Failed to find ladders of ${limit} users from offset=${offset}`,
+          );
     }
   }
 
@@ -51,24 +66,14 @@ export class RanksService {
    * @returns 요청한 유저의 랭킹과 전체 유저 수
    */
   async findPosition(userId: UserId) {
-    const distinctLaddersEntity = this.usersRepository
-      .createQueryBuilder()
-      .select('ladder')
-      .distinct(true);
-    const ranksEntity = this.usersRepository.manager
-      .createQueryBuilder()
-      .select('ladder')
-      .addSelect('ROW_NUMBER() OVER (ORDER BY ladder DESC)', 'rank')
-      .from('distinctLadders', 'distinctLadders');
     try {
       const [{ rank }, total] = await Promise.all([
-        this.usersRepository
+        this.usersRepository.manager
           .createQueryBuilder()
-          .addCommonTableExpression(distinctLaddersEntity, 'distinctLadders')
-          .addCommonTableExpression(ranksEntity, 'ranks')
-          .select('r.rank')
-          .leftJoin('ranks', 'r', 'r.ladder = Users.ladder')
-          .where('Users.user_id = :userId', { userId })
+          .addCommonTableExpression(this.ranksCte, 'Ranks')
+          .select('rank')
+          .from('Ranks', 'Ranks')
+          .where('user_id = :userId', { userId })
           .getRawOne(),
         this.usersRepository.count(),
       ]);

--- a/backend/src/ranks/ranks.service.ts
+++ b/backend/src/ranks/ranks.service.ts
@@ -1,0 +1,55 @@
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { Repository } from 'typeorm';
+
+import { UserId } from '../util/type';
+import { Users } from '../entity/users.entity';
+
+@Injectable()
+export class RanksService {
+  private readonly logger = new Logger(RanksService.name);
+
+  constructor(
+    @InjectRepository(Users)
+    private readonly usersRepository: Repository<Users>,
+  ) {}
+
+  /**
+   * @description 요청한 유저의 랭킹과 전체 유저 수를 반환
+   *
+   * @param userId 요청한 유저의 id
+   * @returns 요청한 유저의 랭킹과 전체 유저 수
+   */
+  async findPosition(userId: UserId) {
+    const distinctLaddersEntity = this.usersRepository
+      .createQueryBuilder()
+      .select('ladder')
+      .distinct(true);
+    const ranksEntity = this.usersRepository.manager
+      .createQueryBuilder()
+      .select('ladder')
+      .addSelect('ROW_NUMBER() OVER (ORDER BY ladder DESC)', 'rank')
+      .from('distinctLadders', 'distinctLadders');
+    try {
+      const [{ rank }, total] = await Promise.all([
+        this.usersRepository
+          .createQueryBuilder()
+          .addCommonTableExpression(distinctLaddersEntity, 'distinctLadders')
+          .addCommonTableExpression(ranksEntity, 'ranks')
+          .select('r.rank')
+          .leftJoin('ranks', 'r', 'r.ladder = Users.ladder')
+          .where('Users.user_id = :userId', { userId })
+          .getRawOne(),
+        this.usersRepository.count(),
+      ]);
+      return { myRank: Number(rank), total };
+    } catch (e) {
+      this.logger.error(e);
+      throw new InternalServerErrorException();
+    }
+  }
+}

--- a/backend/src/ranks/ranks.service.ts
+++ b/backend/src/ranks/ranks.service.ts
@@ -73,7 +73,7 @@ export class RanksService {
           .getRawOne(),
         this.usersRepository.count(),
       ]);
-      return { myRank: Number(rank), total };
+      return { myRank: rank, total };
     } catch (e) {
       this.logger.error(e);
       throw new InternalServerErrorException(

--- a/backend/src/ranks/ranks.service.ts
+++ b/backend/src/ranks/ranks.service.ts
@@ -18,6 +18,32 @@ export class RanksService {
     private readonly usersRepository: Repository<Users>,
   ) {}
 
+  // TODO PIPE 로 range 검증
+  /**
+   * @description offset 부터 limit 만큼 유저의 id 와 ladder 를 랭킹 순으로 나열
+   *
+   * @param offset 시작 index
+   * @param limit 반환할 유저 수
+   * @returns 랭킹 순으로 나열된 유저들의 id 와 ladder
+   */
+  async findLadders(offset: number, limit: number) {
+    try {
+      return {
+        users: await this.usersRepository.find({
+          select: ['userId', 'ladder'],
+          order: { ladder: 'DESC' },
+          skip: offset,
+          take: limit,
+        }),
+      };
+    } catch (e) {
+      this.logger.error(e);
+      throw new InternalServerErrorException(
+        `Failed to find ladders of ${limit} users from offset=${offset}`,
+      );
+    }
+  }
+
   /**
    * @description 요청한 유저의 랭킹과 전체 유저 수를 반환
    *
@@ -49,7 +75,9 @@ export class RanksService {
       return { myRank: Number(rank), total };
     } catch (e) {
       this.logger.error(e);
-      throw new InternalServerErrorException();
+      throw new InternalServerErrorException(
+        `Failed to find the ranking of the user ${userId}`,
+      );
     }
   }
 }


### PR DESCRIPTION
## 개요
- #121 완료

## 작업 사항
- 요청한 유저의 랭킹 & 전체 유저 수 반환하는 findPosition 구현.
  - 사용한 query 가 조금 복잡한데 comment 달아두겠습니다.
- offset 부터 limit 만큼의 유저들을 찾아서 랭킹순으로 id, ladder, rank 반환하는 findLadders 구현.
  - userId 다시 id 로 바꿨습니다.
  - query range 체크는 controller 구현하면서 하겠습니다.
  - postgresql RANK() 함수가 공동 순위까지 다 계산해줘서 서버에서 순위 정보까지 포함해서 보내는 걸로 수정했습니다. 노션 API 설계에도 수정해뒀습니다.

close #121
