### PR TITLE
✨ feat : 유저들의 ProfileImage 가 저장되는 디렉토리 static  호스팅

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/passport": "^9.0.3",
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/platform-socket.io": "^9.2.1",
+        "@nestjs/serve-static": "^3.0.1",
         "@nestjs/typeorm": "^9.0.1",
         "@nestjs/websockets": "^9.2.1",
         "axios": "^1.3.2",
@@ -1723,6 +1724,37 @@
       "peerDependencies": {
         "typescript": "^4.3.5"
       }
+    },
+    "node_modules/@nestjs/serve-static": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-3.0.1.tgz",
+      "integrity": "sha512-i766UJPYOqvQ2BbRKh0/+Mmq5NkJnmKcShjWV1i5qpXyeM0KDZTn0n7g7ykWq/3LbQgjpMzrhYtGv35GX7GVQw==",
+      "dependencies": {
+        "path-to-regexp": "0.2.5"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^6.5.0",
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0",
+        "express": "^4.18.1",
+        "fastify": "^4.7.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "fastify": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/serve-static/node_modules/path-to-regexp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
+      "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q=="
     },
     "node_modules/@nestjs/testing": {
       "version": "9.2.1",
@@ -10875,6 +10907,21 @@
         "fs-extra": "11.1.0",
         "jsonc-parser": "3.2.0",
         "pluralize": "8.0.0"
+      }
+    },
+    "@nestjs/serve-static": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/serve-static/-/serve-static-3.0.1.tgz",
+      "integrity": "sha512-i766UJPYOqvQ2BbRKh0/+Mmq5NkJnmKcShjWV1i5qpXyeM0KDZTn0n7g7ykWq/3LbQgjpMzrhYtGv35GX7GVQw==",
+      "requires": {
+        "path-to-regexp": "0.2.5"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz",
+          "integrity": "sha512-l6qtdDPIkmAmzEO6egquYDfqQGPMRNGjYtrU13HAXb3YSRrt7HSb1sJY0pKp6o2bAa86tSB6iwaW2JbthPKr7Q=="
+        }
       }
     },
     "@nestjs/testing": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/passport": "^9.0.3",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/platform-socket.io": "^9.2.1",
+    "@nestjs/serve-static": "^3.0.1",
     "@nestjs/typeorm": "^9.0.1",
     "@nestjs/websockets": "^9.2.1",
     "axios": "^1.3.2",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,8 @@
 import { ConfigModule } from '@nestjs/config';
 import { Module } from '@nestjs/common';
+import { ServeStaticModule } from '@nestjs/serve-static';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { join } from 'path';
 
 import { ApiConfigModule } from './config/api-config.module';
 import { ApiConfigService } from './config/api-config.service';
@@ -17,6 +19,13 @@ import { UserStatusModule } from './user-status/user-status.module';
   imports: [
     ConfigModule.forRoot({
       envFilePath: './.env',
+    }),
+    ServeStaticModule.forRoot({
+      rootPath: join(__dirname, '..', 'asset'),
+      serveRoot: '/asset/',
+      serveStaticOptions: {
+        index: false,
+      },
     }),
     TypeOrmModule.forRootAsync({
       imports: [ApiConfigModule],


### PR DESCRIPTION
## 개요
- #131 완료

## 작업 사항
- asset directory 를 호스팅 하며 옵션을 잡아줬습니다.
  - 캐싱 설정은 nest.js 가 잘 해주는것 같아 손대지 않았습니다. [옵션별 설명](https://github.com/nestjs/serve-static/blob/master/lib/interfaces/serve-static-options.interface.ts)
  - 제가 설정한 옵션에 대한 설명은 코멘트 달아두겠습니다.

## 변경점
- static serve 를 위한 패키지를 설치했습니다.

## 스크린샷 (optional)
- 확장자 없이 잘 작동하는지 확인하기 위해 nginx 로 간단한 테스트를 해봤습니다.

<img width="984" alt="test" src="https://user-images.githubusercontent.com/79127797/218297217-abde9d5f-1eb1-4b39-b2be-69e80f21db6b.png">

- svg 제외하곤 모두 잘 됩니다.
- 개발자도구의 네트워크 탭을 뜯어보니 확장자가 없는 경우 content-type 을 application/octet-stream 으로 보내는데, svg 는 binary data 가 아니라서 안되는거 같습니다.
- 프사에 svg 를 지원하지 않는게 적절한 해결책이라 생각합니다. ㅎㅎ