### PR TITLE
✨ feat : /game 으로 오는 요청 처리하는 GameController 구현

### DIFF
--- a/backend/src/game/dto/game-gateway.dto.ts
+++ b/backend/src/game/dto/game-gateway.dto.ts
@@ -8,6 +8,10 @@ import {
 } from 'class-validator';
 import { GameId } from '../../util/type';
 
+export interface NewGameDto {
+  gameId: GameId;
+}
+
 export interface GameStartedDto {
   id: GameId;
   left: string;

--- a/backend/src/game/dto/game-gateway.dto.ts
+++ b/backend/src/game/dto/game-gateway.dto.ts
@@ -2,7 +2,7 @@ import {
   ArrayUnique,
   IsInt,
   IsString,
-  Length,
+  Matches,
   Max,
   Min,
 } from 'class-validator';
@@ -20,7 +20,7 @@ export interface GameAbortedDto {
 
 export class GameCompleteDto {
   @IsString()
-  @Length(21)
+  @Matches(/^[0-9A-Za-z_-]{21}$/)
   id: GameId;
 
   @ArrayUnique()

--- a/backend/src/game/dto/game-gateway.dto.ts
+++ b/backend/src/game/dto/game-gateway.dto.ts
@@ -12,6 +12,10 @@ export interface NewGameDto {
   gameId: GameId;
 }
 
+export interface GameOptionDto {
+  map: 1 | 2 | 3;
+}
+
 export interface GameStartedDto {
   id: GameId;
   left: string;

--- a/backend/src/game/dto/game.dto.ts
+++ b/backend/src/game/dto/game.dto.ts
@@ -1,4 +1,16 @@
-import { UserId } from '../../util/type';
+import { IsString, Matches } from 'class-validator';
+
+import { GameId, UserId } from '../../util/type';
+
+export class GameIdParamDto {
+  @IsString()
+  @Matches(/^[0-9A-Za-z_-]{21}$/)
+  gameId: GameId;
+}
+
+export interface LadderGamesDto {
+  games: { id: GameId; left: string; right: string }[];
+}
 
 export interface GameInfoDto {
   leftPlayer: string;

--- a/backend/src/game/dto/game.dto.ts
+++ b/backend/src/game/dto/game.dto.ts
@@ -1,6 +1,6 @@
 import { IsIn, IsString, Matches } from 'class-validator';
 
-import { GameId, UserId } from '../../util/type';
+import { GameId, Score, UserId } from '../../util/type';
 
 export class GameIdParamDto {
   @IsString()
@@ -18,12 +18,15 @@ export interface LadderGamesDto {
 }
 
 export interface GameInfoDto {
+  isRank: boolean;
   leftPlayer: string;
   rightPlayer: string;
   map: number;
+  scores: [Score, Score] | null;
 }
 
 export interface PlayersDto {
+  isRank: boolean;
   isLeft: boolean;
   playerId: UserId;
   playerNickname: string;

--- a/backend/src/game/dto/game.dto.ts
+++ b/backend/src/game/dto/game.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, Matches } from 'class-validator';
+import { IsIn, IsString, Matches } from 'class-validator';
 
 import { GameId, UserId } from '../../util/type';
 
@@ -6,6 +6,11 @@ export class GameIdParamDto {
   @IsString()
   @Matches(/^[0-9A-Za-z_-]{21}$/)
   gameId: GameId;
+}
+
+export class GameMapDto {
+  @IsIn([1, 2, 3])
+  map: 1 | 2 | 3;
 }
 
 export interface LadderGamesDto {

--- a/backend/src/game/game.controller.ts
+++ b/backend/src/game/game.controller.ts
@@ -1,9 +1,19 @@
-import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Req,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
 
 import { GameIdParamDto } from './dto/game.dto';
 import { GameService } from './game.service';
+import { InPlayGuard } from './guard/in-play.guard';
+import { LadderQueueInterceptor } from './interceptor/ladder-queue.interceptor';
 import { MockAuthGuard } from '../guard/mock-auth.guard';
-import { VerifiedRequest } from '../../dist/util/type.d';
+import { VerifiedRequest } from '../util/type';
 
 // FIXME: AuthGuard 구현 후 변경
 @UseGuards(MockAuthGuard)
@@ -28,6 +38,13 @@ export class GameController {
     @Param() { gameId }: GameIdParamDto,
   ) {
     return this.gameService.findGameInfo(req.user.userId, gameId);
+  }
+
+  @UseGuards(InPlayGuard)
+  @UseInterceptors(LadderQueueInterceptor)
+  @Post('queue')
+  enterLadderQueue() {
+    return;
   }
 
   /*****************************************************************************

--- a/backend/src/game/game.controller.ts
+++ b/backend/src/game/game.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Param, Req, UseGuards } from '@nestjs/common';
+
+import { GameIdParamDto } from './dto/game.dto';
+import { GameService } from './game.service';
+import { MockAuthGuard } from '../guard/mock-auth.guard';
+import { VerifiedRequest } from '../../dist/util/type.d';
+
+// FIXME: AuthGuard 구현 후 변경
+@UseGuards(MockAuthGuard)
+@Controller('game')
+export class GameController {
+  constructor(private readonly gameService: GameService) {}
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Waiting room                                                    *
+   *                                                                           *
+   ****************************************************************************/
+
+  @Get('list')
+  findLadderGames() {
+    return this.gameService.findLadderGames();
+  }
+
+  @Get('list/:gameId')
+  findGameInfo(
+    @Req() req: VerifiedRequest,
+    @Param() { gameId }: GameIdParamDto,
+  ) {
+    return this.gameService.findGameInfo(req.user.userId, gameId);
+  }
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Game UI                                                         *
+   *                                                                           *
+   ****************************************************************************/
+}

--- a/backend/src/game/game.controller.ts
+++ b/backend/src/game/game.controller.ts
@@ -56,6 +56,14 @@ export class GameController {
    *                                                                           *
    ****************************************************************************/
 
+  @Get(':gameId')
+  findPlayers(
+    @Req() req: VerifiedRequest,
+    @Param() { gameId }: GameIdParamDto,
+  ) {
+    return this.gameService.findPlayers(req.user.userId, gameId);
+  }
+
   @UseGuards(InGameUiGuard)
   @Patch(':gameId/options')
   updateMap(

--- a/backend/src/game/game.controller.ts
+++ b/backend/src/game/game.controller.ts
@@ -15,6 +15,7 @@ import { GameService } from './game.service';
 import { InGameUiGuard } from './guard/in-game-ui.guard';
 import { InPlayGuard } from './guard/in-play.guard';
 import { LadderQueueInterceptor } from './interceptor/ladder-queue.interceptor';
+import { LadderStartInterceptor } from './interceptor/ladder-start.interceptor';
 import { MockAuthGuard } from '../guard/mock-auth.guard';
 import { VerifiedRequest } from '../util/type';
 
@@ -72,5 +73,12 @@ export class GameController {
     @Body() { map }: GameMapDto,
   ) {
     this.gameService.changeMap(req.user.userId, gameId, map);
+  }
+
+  @UseGuards(InGameUiGuard)
+  @UseInterceptors(LadderStartInterceptor)
+  @Patch(':gameId/start')
+  startGame() {
+    return;
   }
 }

--- a/backend/src/game/game.controller.ts
+++ b/backend/src/game/game.controller.ts
@@ -1,15 +1,18 @@
 import {
+  Body,
   Controller,
   Get,
   Param,
+  Patch,
   Post,
   Req,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 
-import { GameIdParamDto } from './dto/game.dto';
+import { GameIdParamDto, GameMapDto } from './dto/game.dto';
 import { GameService } from './game.service';
+import { InGameUiGuard } from './guard/in-game-ui.guard';
 import { InPlayGuard } from './guard/in-play.guard';
 import { LadderQueueInterceptor } from './interceptor/ladder-queue.interceptor';
 import { MockAuthGuard } from '../guard/mock-auth.guard';
@@ -52,4 +55,14 @@ export class GameController {
    * SECTION : Game UI                                                         *
    *                                                                           *
    ****************************************************************************/
+
+  @UseGuards(InGameUiGuard)
+  @Patch(':gameId/options')
+  updateMap(
+    @Req() req: VerifiedRequest,
+    @Param() { gameId }: GameIdParamDto,
+    @Body() { map }: GameMapDto,
+  ) {
+    this.gameService.changeMap(req.user.userId, gameId, map);
+  }
 }

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -73,11 +73,15 @@ export class GameGateway {
   /**
    * @description: 게임 옵션 전송
    *
-   * @param invitedSocketId 초대된 유저의 socket id
+   * @param gameId 게임 id
+   * @param ignoreSocketId 무시할 socket id
    * @param map 맵
    */
-  emitGameOption(invitedSocketId: SocketId, map: 1 | 2 | 3) {
-    this.server.to(invitedSocketId).emit('gameOption', { map });
+  emitGameOption(gameId: GameId, ignoreSocketId: SocketId, map: 1 | 2 | 3) {
+    this.server
+      .to(`game-${gameId}`)
+      .except(ignoreSocketId)
+      .emit('gameOption', { map });
   }
 
   // NOTE : ladder 일 때만 호출

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -95,7 +95,12 @@ export class GameGateway {
     this.server.to('waitingRoom').emit('gameStarted', gameStartedDto);
   }
 
+  // TODO : gameStatus listener
   // TODO : gameStatus emitter
+  // FIXME : 메시지 추가
+  emitGameStatus(gameId: GameId) {
+    this.server.to(`game-${gameId}`).emit('gameStatus');
+  }
 
   /**
    * @description 게임 비정상 종료 처리

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -1,7 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-// import { GameController } from './game.controller';
+import { GameController } from './game.controller';
 import { GameGateway } from './game.gateway';
 import { GameService } from './game.service';
 import { GameStorage } from './game.storage';
@@ -16,7 +16,7 @@ import { Users } from '../entity/users.entity';
     RanksModule,
     forwardRef(() => UserStatusModule),
   ],
-  // controllers: [GameController],
+  controllers: [GameController],
   providers: [GameGateway, GameService, GameStorage],
   exports: [GameGateway, GameService, GameStorage],
 })

--- a/backend/src/game/game.service.spec.ts
+++ b/backend/src/game/game.service.spec.ts
@@ -1,12 +1,8 @@
 import { DataSource } from 'typeorm';
-import {
-  BadRequestException,
-  ConflictException,
-  ForbiddenException,
-  NotFoundException,
-} from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { faker } from '@faker-js/faker';
 import { nanoid } from 'nanoid';
 
 import { BlockedUsers } from '../entity/blocked-users.entity';
@@ -50,7 +46,7 @@ describe('GameService', () => {
     const dataSources = await createDataSources(TEST_DB, ENTITIES);
     initDataSource = dataSources.initDataSource;
     dataSource = dataSources.dataSource;
-    usersEntities = generateUsers(100);
+    usersEntities = generateUsers(200);
     await dataSource.getRepository(Users).insert(usersEntities);
   });
 
@@ -115,30 +111,32 @@ describe('GameService', () => {
 
   describe('GAME LIST', () => {
     it('should return an empty list of games', () => {
-      expect(service.findGames()).toEqual([]);
+      expect(service.findLadderGames()).toEqual({ games: [] });
     });
 
-    it('should return a list of games', async () => {
+    it('should return a list of ladder games', async () => {
       const games = [];
-      for (let i = index; i < 10; i++) {
+      for (let i = index; i < 50; i++) {
         const newGameId = nanoid();
+        const isRank = faker.datatype.boolean();
         await gameStorage.createGame(
           newGameId,
           new GameInfo(
             usersEntities[i].userId,
             usersEntities[i + 1].userId,
             1,
-            true,
+            isRank,
           ),
         );
-        games.push({
-          id: newGameId,
-          left: usersEntities[i].nickname,
-          right: usersEntities[i + 1].nickname,
-        });
+        isRank &&
+          games.push({
+            id: newGameId,
+            left: usersEntities[i].nickname,
+            right: usersEntities[i + 1].nickname,
+          });
       }
-      index += 10;
-      expect(service.findGames()).toEqual(games.reverse());
+      index += 100;
+      expect(service.findLadderGames()).toEqual({ games: games.reverse() });
     });
   });
 

--- a/backend/src/game/game.service.spec.ts
+++ b/backend/src/game/game.service.spec.ts
@@ -147,15 +147,32 @@ describe('GameService', () => {
   });
 
   describe('SPECTATOR', () => {
-    it('should return game information when a user tries to spectate a game', async () => {
+    it('should return game information when a user tries to spectate a normal game before it starts', async () => {
+      await gameStorage.createGame(
+        gameId,
+        new GameInfo(playerOne.userId, playerTwo.userId, 1, false),
+      );
+      expect(service.findGameInfo(spectatorOne.userId, gameId)).toEqual({
+        isRank: false,
+        leftPlayer: playerOne.nickname,
+        rightPlayer: playerTwo.nickname,
+        map: 1,
+        scores: null,
+      });
+    });
+
+    it('should return game information when a user tries to spectate a game (in progress)', async () => {
       await gameStorage.createGame(
         gameId,
         new GameInfo(playerOne.userId, playerTwo.userId, 1, true),
       );
+      (gameStorage as any).games.get(gameId).scores = [1, 2];
       expect(service.findGameInfo(spectatorOne.userId, gameId)).toEqual({
+        isRank: true,
         leftPlayer: playerOne.nickname,
         rightPlayer: playerTwo.nickname,
         map: 1,
+        scores: [1, 2],
       });
     });
 
@@ -290,17 +307,33 @@ describe('GameService', () => {
   });
 
   describe('START THE GAME', () => {
-    it("should return pleyer's info and on which side they are", async () => {
+    it("should return normal game pleyer's info and on which side they are", async () => {
       await gameStorage.createGame(
         gameId,
         new GameInfo(playerOne.userId, playerTwo.userId, 1, false),
       );
       expect(service.findPlayers(playerOne.userId, gameId)).toEqual({
+        isRank: false,
         isLeft: true,
         playerId: playerOne.userId,
         playerNickname: playerOne.nickname,
         opponentId: playerTwo.userId,
         opponentNickname: playerTwo.nickname,
+      });
+    });
+
+    it("should return ladder game pleyer's info and on which side they are", async () => {
+      await gameStorage.createGame(
+        gameId,
+        new GameInfo(playerOne.userId, playerTwo.userId, 1, true),
+      );
+      expect(service.findPlayers(playerTwo.userId, gameId)).toEqual({
+        isRank: true,
+        isLeft: false,
+        playerId: playerTwo.userId,
+        playerNickname: playerTwo.nickname,
+        opponentId: playerOne.userId,
+        opponentNickname: playerOne.nickname,
       });
     });
 

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -52,8 +52,15 @@ export class GameService {
    */
   findGameInfo(spectatorId: UserId, gameId: GameId) {
     const gameInfo = this.getExistingGame(spectatorId, gameId);
-    const { leftId, leftNickname, rightId, rightNickname, map, isRank } =
-      gameInfo;
+    const {
+      leftId,
+      leftNickname,
+      rightId,
+      rightNickname,
+      map,
+      isRank,
+      scores,
+    } = gameInfo;
     const [leftRelationship, rightRelationship] = [
       this.userRelationshipStorage.getRelationship(spectatorId, leftId),
       this.userRelationshipStorage.getRelationship(spectatorId, rightId),
@@ -71,10 +78,15 @@ export class GameService {
       this.userSocketStorage.clients.get(spectatorId),
       `game-${gameId}`,
     );
-    return { leftPlayer: leftNickname, rightPlayer: rightNickname, map };
+    return {
+      isRank,
+      leftPlayer: leftNickname,
+      rightPlayer: rightNickname,
+      map,
+      scores,
+    };
   }
 
-  // TODO : `game-${gameId}` ui 밖에서 요청하면 400 Guard 로 처리
   // TODO : interceptor 로 두 플레이어 모두 해당 요청에 응답 보냈을 때 게임 시작 event emit
   /**
    * @description 게임에 참여하는 유저에게 게임의 기본 정보 제공
@@ -85,7 +97,7 @@ export class GameService {
    */
   findPlayers(playerId: UserId, gameId: GameId) {
     const gameInfo = this.getExistingGame(playerId, gameId);
-    const { leftId, leftNickname, rightId, rightNickname } = gameInfo;
+    const { isRank, leftId, leftNickname, rightId, rightNickname } = gameInfo;
     if (leftId !== playerId && rightId !== playerId) {
       throw new ForbiddenException(
         `The requester(${playerId}) is not a participant of the game`,
@@ -95,7 +107,14 @@ export class GameService {
     const [playerNickname, opponentId, opponentNickname] = isLeft
       ? [leftNickname, rightId, rightNickname]
       : [rightNickname, leftId, leftNickname];
-    return { isLeft, playerId, playerNickname, opponentId, opponentNickname };
+    return {
+      isRank,
+      isLeft,
+      playerId,
+      playerNickname,
+      opponentId,
+      opponentNickname,
+    };
   }
 
   /**

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -167,7 +167,7 @@ export class GameService {
    * @param gameId 게임 id
    * @returns 게임 정보
    */
-  getExistingGame(requesterId: UserId, gameId: GameId) {
+  private getExistingGame(requesterId: UserId, gameId: GameId) {
     const gameInfo = this.gameStorage.getGame(gameId);
     if (gameInfo === undefined) {
       throw new NotFoundException(

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -138,7 +139,7 @@ export class GameService {
       );
     }
     if (gameInfo.isRank) {
-      throw new ForbiddenException(
+      throw new BadRequestException(
         `The requester(${requesterId}) cannot change map of a ladder game`,
       );
     }
@@ -149,7 +150,8 @@ export class GameService {
     }
     gameInfo.map = map;
     this.gameGateway.emitGameOption(
-      this.userSocketStorage.clients.get(gameInfo.rightId),
+      gameId,
+      this.userSocketStorage.clients.get(gameInfo.leftId),
       map,
     );
   }

--- a/backend/src/game/guard/in-game-ui.guard.ts
+++ b/backend/src/game/guard/in-game-ui.guard.ts
@@ -1,0 +1,25 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+} from '@nestjs/common';
+
+import { ActivityManager } from '../../user-status/activity.manager';
+import { VerifiedRequest } from '../../util/type';
+
+@Injectable()
+export class InGameUiGuard implements CanActivate {
+  constructor(private readonly activityManager: ActivityManager) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const {
+      user: { userId },
+      params,
+    } = context.switchToHttp().getRequest<VerifiedRequest>();
+    if (this.activityManager.getActivity(userId) !== `game-${params.gameId}`) {
+      throw new BadRequestException(`The player(${userId}) is not in game UI`);
+    }
+    return true;
+  }
+}

--- a/backend/src/game/guard/in-play.guard.ts
+++ b/backend/src/game/guard/in-play.guard.ts
@@ -1,0 +1,26 @@
+import {
+  CanActivate,
+  BadRequestException,
+  ExecutionContext,
+  Injectable,
+} from '@nestjs/common';
+
+import { GameStorage } from '../game.storage';
+import { VerifiedRequest } from '../../util/type';
+
+@Injectable()
+export class InPlayGuard implements CanActivate {
+  constructor(private readonly gameStorage: GameStorage) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const {
+      user: { userId },
+    } = context.switchToHttp().getRequest<VerifiedRequest>();
+    if (this.gameStorage.players.has(userId)) {
+      throw new BadRequestException(
+        `The player(${userId}) is already in a game`,
+      );
+    }
+    return true;
+  }
+}

--- a/backend/src/game/guard/in-play.guard.ts
+++ b/backend/src/game/guard/in-play.guard.ts
@@ -1,6 +1,6 @@
 import {
-  CanActivate,
   BadRequestException,
+  CanActivate,
   ExecutionContext,
   Injectable,
 } from '@nestjs/common';

--- a/backend/src/game/interceptor/ladder-queue.interceptor.ts
+++ b/backend/src/game/interceptor/ladder-queue.interceptor.ts
@@ -5,7 +5,7 @@ import {
   Injectable,
   NestInterceptor,
 } from '@nestjs/common';
-import { Observable, Subject, bufferCount, tap } from 'rxjs';
+import { Observable, ReplaySubject, bufferCount, tap } from 'rxjs';
 
 import { GameService } from '../game.service';
 import { UserId, VerifiedRequest } from '../../util/type';
@@ -13,7 +13,7 @@ import { UserId, VerifiedRequest } from '../../util/type';
 @Injectable()
 export class LadderQueueInterceptor implements NestInterceptor {
   private readonly usersInQueue: Set<UserId> = new Set();
-  private readonly waitingQueue: Subject<UserId> = new Subject();
+  private readonly waitingQueue: ReplaySubject<UserId> = new ReplaySubject();
 
   constructor(private readonly gameService: GameService) {
     this.waitingQueue

--- a/backend/src/game/interceptor/ladder-queue.interceptor.ts
+++ b/backend/src/game/interceptor/ladder-queue.interceptor.ts
@@ -6,55 +6,34 @@ import {
   NestInterceptor,
 } from '@nestjs/common';
 import { Observable, Subject, bufferCount, tap } from 'rxjs';
-import { nanoid } from 'nanoid';
 
-import { GameGateway } from '../game.gateway';
-import { GameStorage } from '../game.storage';
-import { GameInfo, UserId, VerifiedRequest } from '../../util/type';
-import { UserSocketStorage } from '../../user-status/user-socket.storage';
+import { GameService } from '../game.service';
+import { UserId, VerifiedRequest } from '../../util/type';
 
 @Injectable()
 export class LadderQueueInterceptor implements NestInterceptor {
   private readonly usersInQueue: Set<UserId> = new Set();
   private readonly waitingQueue: Subject<UserId> = new Subject();
 
-  constructor(
-    private readonly gameGateway: GameGateway,
-    private readonly gameStorage: GameStorage,
-    private readonly userSocketStorage: UserSocketStorage,
-  ) {
+  constructor(private readonly gameService: GameService) {
     this.waitingQueue
       .pipe(bufferCount(2))
-      .subscribe(this.createGame.bind(this));
+      .subscribe((players: [UserId, UserId]) => {
+        players.forEach((userId) => this.usersInQueue.delete(userId));
+        this.gameService.createLadderGame(players);
+      });
   }
 
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<void> {
     const {
       user: { userId },
     } = context.switchToHttp().getRequest<VerifiedRequest>();
     if (this.usersInQueue.has(userId)) {
       throw new ConflictException(
-        `The user(${userId}) is already in the queue`,
+        `The user(${userId}) has already entered the queue`,
       );
     }
     this.usersInQueue.add(userId);
     return next.handle().pipe(tap(() => this.waitingQueue.next(userId)));
-  }
-
-  private async createGame(players: [UserId, UserId]) {
-    if (players.length !== 2) return;
-    players.forEach((userId) => this.usersInQueue.delete(userId));
-    const gameId = nanoid();
-    await this.gameStorage.createGame(
-      gameId,
-      new GameInfo(players[0], players[1], 1, true),
-    );
-    players.forEach((userId) =>
-      this.gameGateway.joinRoom(
-        this.userSocketStorage.clients.get(userId),
-        `game-${gameId}`,
-      ),
-    );
-    this.gameGateway.emitNewGame(gameId);
   }
 }

--- a/backend/src/game/interceptor/ladder-queue.interceptor.ts
+++ b/backend/src/game/interceptor/ladder-queue.interceptor.ts
@@ -1,0 +1,60 @@
+import {
+  CallHandler,
+  ConflictException,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, Subject, bufferCount, tap } from 'rxjs';
+import { nanoid } from 'nanoid';
+
+import { GameGateway } from '../game.gateway';
+import { GameStorage } from '../game.storage';
+import { GameInfo, UserId, VerifiedRequest } from '../../util/type';
+import { UserSocketStorage } from '../../user-status/user-socket.storage';
+
+@Injectable()
+export class LadderQueueInterceptor implements NestInterceptor {
+  private readonly usersInQueue: Set<UserId> = new Set();
+  private readonly waitingQueue: Subject<UserId> = new Subject();
+
+  constructor(
+    private readonly gameGateway: GameGateway,
+    private readonly gameStorage: GameStorage,
+    private readonly userSocketStorage: UserSocketStorage,
+  ) {
+    this.waitingQueue
+      .pipe(bufferCount(2))
+      .subscribe(this.createGame.bind(this));
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const {
+      user: { userId },
+    } = context.switchToHttp().getRequest<VerifiedRequest>();
+    if (this.usersInQueue.has(userId)) {
+      throw new ConflictException(
+        `The user(${userId}) is already in the queue`,
+      );
+    }
+    this.usersInQueue.add(userId);
+    return next.handle().pipe(tap(() => this.waitingQueue.next(userId)));
+  }
+
+  private async createGame(players: [UserId, UserId]) {
+    if (players.length !== 2) return;
+    players.forEach((userId) => this.usersInQueue.delete(userId));
+    const gameId = nanoid();
+    await this.gameStorage.createGame(
+      gameId,
+      new GameInfo(players[0], players[1], 1, true),
+    );
+    players.forEach((userId) =>
+      this.gameGateway.joinRoom(
+        this.userSocketStorage.clients.get(userId),
+        `game-${gameId}`,
+      ),
+    );
+    this.gameGateway.emitNewGame(gameId);
+  }
+}

--- a/backend/src/game/interceptor/ladder-start.interceptor.ts
+++ b/backend/src/game/interceptor/ladder-start.interceptor.ts
@@ -1,0 +1,85 @@
+import {
+  BadRequestException,
+  CallHandler,
+  ConflictException,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NestInterceptor,
+  NotFoundException,
+} from '@nestjs/common';
+import { Observable, Subject, bufferCount, tap } from 'rxjs';
+
+import { GameId, GameInfo, UserId, VerifiedRequest } from '../../util/type';
+import { GameService } from '../game.service';
+import { GameStorage } from '../game.storage';
+
+@Injectable()
+export class LadderStartInterceptor implements NestInterceptor {
+  private readonly gameSubjectMap: Map<GameId, Subject<UserId>> = new Map();
+  private readonly waitingPlayers: Set<UserId> = new Set();
+
+  constructor(
+    private readonly gameService: GameService,
+    private readonly gameStorage: GameStorage,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<void> {
+    const {
+      user: { userId },
+      params: { gameId },
+    } = context.switchToHttp().getRequest<VerifiedRequest>();
+    const gameInfo = this.gameStorage.getGame(gameId);
+    this.checkGameInfo(userId, gameId, gameInfo);
+    if (this.waitingPlayers.has(userId)) {
+      throw new ConflictException(
+        `The user(${userId}) has already entered the game start queue`,
+      );
+    }
+    this.waitingPlayers.add(userId);
+    return next.handle().pipe(
+      tap(() => {
+        const queue = this.gameSubjectMap.get(gameId);
+        queue === undefined
+          ? this.createGameStartQueue(userId, gameId, gameInfo)
+          : queue.next(userId);
+      }),
+    );
+  }
+
+  private checkGameInfo(
+    requesterId: UserId,
+    gameId: GameId,
+    gameInfo: GameInfo,
+  ) {
+    if (gameInfo === undefined) {
+      throw new NotFoundException(`The game(${gameId}) does not exist`);
+    }
+    const { leftId, rightId, scores } = gameInfo;
+    if (leftId !== requesterId && rightId !== requesterId) {
+      throw new ForbiddenException(
+        `The user(${requesterId}) is not a player of the game(${gameId})`,
+      );
+    }
+    if (scores !== null) {
+      throw new BadRequestException(
+        `The game(${gameId}) has already been started`,
+      );
+    }
+  }
+
+  private createGameStartQueue(
+    requesterId: UserId,
+    gameId: GameId,
+    gameInfo: GameInfo,
+  ) {
+    const queue = new Subject<UserId>();
+    queue.pipe(bufferCount(2)).subscribe((players: [UserId, UserId]) => {
+      players.forEach((userId) => this.waitingPlayers.delete(userId));
+      this.gameService.startGame(gameId, gameInfo);
+      this.gameSubjectMap.delete(gameId);
+    });
+    this.gameSubjectMap.set(gameId, queue);
+    queue.next(requesterId);
+  }
+}

--- a/backend/src/game/interceptor/ladder-start.interceptor.ts
+++ b/backend/src/game/interceptor/ladder-start.interceptor.ts
@@ -8,7 +8,7 @@ import {
   NestInterceptor,
   NotFoundException,
 } from '@nestjs/common';
-import { Observable, Subject, bufferCount, tap } from 'rxjs';
+import { Observable, ReplaySubject, bufferCount, tap } from 'rxjs';
 
 import { GameId, GameInfo, UserId, VerifiedRequest } from '../../util/type';
 import { GameService } from '../game.service';
@@ -16,7 +16,8 @@ import { GameStorage } from '../game.storage';
 
 @Injectable()
 export class LadderStartInterceptor implements NestInterceptor {
-  private readonly gameSubjectMap: Map<GameId, Subject<UserId>> = new Map();
+  private readonly gameSubjectMap: Map<GameId, ReplaySubject<UserId>> =
+    new Map();
   private readonly waitingPlayers: Set<UserId> = new Set();
 
   constructor(
@@ -73,7 +74,7 @@ export class LadderStartInterceptor implements NestInterceptor {
     gameId: GameId,
     gameInfo: GameInfo,
   ) {
-    const queue = new Subject<UserId>();
+    const queue = new ReplaySubject<UserId>();
     queue.pipe(bufferCount(2)).subscribe((players: [UserId, UserId]) => {
       players.forEach((userId) => this.waitingPlayers.delete(userId));
       this.gameService.startGame(gameId, gameInfo);

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -157,13 +157,10 @@ export class ActivityGateway
     if (currentUi) {
       activity = currentUi.startsWith('game-') ? 'inGame' : 'online';
     }
-
-    // TODO : 게임 중이라면 GameStorage 에서 gameId 가져오기
     const gameId = this.gameStorage.players.get(targetId) ?? null;
-
     return {
       activity,
-      gameId,
+      gameId: activity === 'inGame' ? gameId : null,
       userId: targetId,
     };
   }

--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -44,6 +44,8 @@ export type CurrentUi =
 
 export type Activity = 'online' | 'offline' | 'inGame';
 
+export type Score = 0 | 1 | 2 | 3 | 4 | 5;
+
 export class GameInfo {
   constructor(
     leftId: UserId,
@@ -55,6 +57,7 @@ export class GameInfo {
     this.rightId = rightId;
     this.map = map;
     this.isRank = isRank;
+    this.scores = null;
   }
 
   isRank: boolean;
@@ -63,6 +66,7 @@ export class GameInfo {
   rightId: UserId;
   rightNickname?: string;
   map: 1 | 2 | 3;
+  scores: [Score, Score] | null;
 }
 
 export interface VerifiedRequest extends Request {

--- a/backend/test/game.e2e-spec.ts
+++ b/backend/test/game.e2e-spec.ts
@@ -1,0 +1,278 @@
+import { DataSource } from 'typeorm';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Socket, io } from 'socket.io-client';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { faker } from '@faker-js/faker';
+import { nanoid } from 'nanoid';
+import * as request from 'supertest';
+import waitForExpect from 'wait-for-expect';
+
+import { ActivityManager } from '../src/user-status/activity.manager';
+import { AppModule } from '../src/app.module';
+import { BlockedUsers } from '../src/entity/blocked-users.entity';
+import { GameGateway } from '../src/game/game.gateway';
+import { GameInfo, UserId } from '../src/util/type';
+import { GameStorage } from '../src/game/game.storage';
+import {
+  TYPEORM_SHARED_CONFIG,
+  createDataSources,
+  destroyDataSources,
+} from './util/db-resource-manager';
+import { UserRelationshipStorage } from '../src/user-status/user-relationship.storage';
+import { Users } from '../src/entity/users.entity';
+import { generateUsers } from './util/generate-mock-data';
+import { listenPromise } from './util/util';
+
+const TEST_DB = 'test_db_game_e2e';
+const ENTITIES = [BlockedUsers, Users];
+
+const PORT = 4249;
+const URL = `http://localhost:${PORT}`;
+
+process.env.NODE_ENV = 'development';
+process.env.DB_HOST = 'localhost';
+
+describe('GameController (e2e)', () => {
+  let app: INestApplication;
+  let activityManager: ActivityManager;
+  let clientSockets: Socket[];
+  let gameGateway: GameGateway;
+  let gameStorage: GameStorage;
+  let userRelationshipStorage: UserRelationshipStorage;
+  let dataSource: DataSource;
+  let initDataSource: DataSource;
+  let usersEntities: Users[];
+  let users: Users[];
+  let userIds: UserId[];
+  let index = 0;
+
+  beforeAll(async () => {
+    const dataSources = await createDataSources(TEST_DB, ENTITIES);
+    initDataSource = dataSources.initDataSource;
+    dataSource = dataSources.dataSource;
+    usersEntities = generateUsers(200);
+    await dataSource.manager.save(usersEntities);
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'postgres',
+          ...TYPEORM_SHARED_CONFIG,
+          autoLoadEntities: true,
+          database: TEST_DB,
+        }),
+        AppModule,
+      ],
+    }).compile();
+    app = moduleFixture.createNestApplication();
+    activityManager = app.get(ActivityManager);
+    gameGateway = app.get(GameGateway);
+    gameStorage = app.get(GameStorage);
+    userRelationshipStorage = app.get(UserRelationshipStorage);
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+    await app.listen(PORT);
+  });
+
+  beforeEach(async () => {
+    users = usersEntities.slice(index, index + 4);
+    userIds = users.map(({ userId }) => userId);
+    clientSockets = await Promise.all(
+      userIds.map(async (id) => {
+        const socket = io(URL, {
+          extraHeaders: { 'x-user-id': id.toString() },
+        });
+        return listenPromise(socket, 'connect').then(() => socket);
+      }),
+    );
+    clientSockets.forEach((socket) =>
+      socket.emit('currentUi', { ui: 'profile' }),
+    );
+    await waitForExpect(() => {
+      userIds.forEach((id) =>
+        expect(activityManager.getActivity(id)).toBe('profile'),
+      );
+    });
+  });
+
+  afterEach(() => clientSockets.forEach((socket) => socket.disconnect()));
+
+  afterAll(async () => {
+    await app.close();
+    await destroyDataSources(TEST_DB, dataSource, initDataSource);
+  });
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Waiting room                                                    *
+   *                                                                           *
+   ****************************************************************************/
+
+  /*****************************************************************************
+   *                                                                           *
+   * ANCHOR : GET /game/list                                                   *
+   *                                                                           *
+   ****************************************************************************/
+
+  describe('GET /game/list', () => {
+    it('should return an empty list (200)', () => {
+      return request(app.getHttpServer())
+        .get('/game/list')
+        .set('x-user-id', userIds[0].toString())
+        .expect(200)
+        .expect({ games: [] });
+    });
+
+    it('should return a list of ladder games (200)', async () => {
+      const games = [];
+      for (let i = index; i < 25; i++) {
+        const newGameId = nanoid();
+        const isRank = faker.datatype.boolean();
+        await gameStorage.createGame(
+          newGameId,
+          new GameInfo(
+            usersEntities[i].userId,
+            usersEntities[i + 1].userId,
+            1,
+            isRank,
+          ),
+        );
+        isRank &&
+          games.push({
+            id: newGameId,
+            left: usersEntities[i].nickname,
+            right: usersEntities[i + 1].nickname,
+          });
+      }
+      index += 50;
+      return request(app.getHttpServer())
+        .get('/game/list')
+        .set('x-user-id', userIds[0].toString())
+        .expect(200)
+        .expect({ games: games.reverse() });
+    });
+  });
+
+  /*****************************************************************************
+   *                                                                           *
+   * ANCHOR : GET /game/list/:gameId                                           *
+   *                                                                           *
+   ****************************************************************************/
+
+  describe('GET /game/list/:gameId', () => {
+    it("should return a ladder game's info (200)", async () => {
+      const [playerOne, playerTwo, spectator] = userIds;
+      const gameId = nanoid();
+      await gameStorage.createGame(
+        gameId,
+        new GameInfo(playerOne, playerTwo, 1, true),
+      );
+      const { status, body } = await request(app.getHttpServer())
+        .get(`/game/list/${gameId}`)
+        .set('x-user-id', spectator.toString());
+      expect(status).toBe(200);
+      expect(body).toEqual({
+        leftPlayer: users[0].nickname,
+        rightPlayer: users[1].nickname,
+        map: 1,
+      });
+      await waitForExpect(() => {
+        expect(
+          (gameGateway as any).server
+            .in(`game-${gameId}`)
+            .fetchSockets()
+            .then((sockets) => sockets.map(({ id }) => id)),
+        ).resolves.toContain(clientSockets[2].id);
+      });
+    });
+
+    it("should return a normal game's info (200)", async () => {
+      const [playerOne, playerTwo, spectator] = userIds;
+      const gameId = nanoid();
+      await gameStorage.createGame(
+        gameId,
+        new GameInfo(playerOne, playerTwo, 1, false),
+      );
+      const { status, body } = await request(app.getHttpServer())
+        .get(`/game/list/${gameId}`)
+        .set('x-user-id', spectator.toString());
+      expect(status).toBe(200);
+      expect(body).toEqual({
+        leftPlayer: users[0].nickname,
+        rightPlayer: users[1].nickname,
+        map: 1,
+      });
+      await waitForExpect(() => {
+        expect(
+          (gameGateway as any).server
+            .in(`game-${gameId}`)
+            .fetchSockets()
+            .then((sockets) => sockets.map(({ id }) => id)),
+        ).resolves.toContain(clientSockets[2].id);
+      });
+    });
+
+    it('should throw BAD REQUEST if the game id is invalid (400)', async () => {
+      (
+        await Promise.allSettled([
+          request(app.getHttpServer())
+            .get(`/game/list/invalid`)
+            .set('x-user-id', userIds[0].toString())
+            .expect(400),
+          request(app.getHttpServer())
+            .get(`/game/list/${nanoid(22)}`)
+            .set('x-user-id', userIds[0].toString())
+            .expect(400),
+          request(app.getHttpServer())
+            .get(`/game/list/${nanoid(10) + '*' + nanoid(10)}`)
+            .set('x-user-id', userIds[0].toString())
+            .expect(400),
+        ])
+      ).forEach((result) => expect(result.status).toBe('fulfilled'));
+    });
+
+    it('should throw FORBIDDEN if the spectator to a normal game is either a blocker to or blocked by either of the players (403)', async () => {
+      const [playerOne, playerTwo, spectatorOne, spectatorTwo] = userIds;
+      const gameId = nanoid();
+      await Promise.all([
+        gameStorage.createGame(
+          gameId,
+          new GameInfo(playerOne, playerTwo, 1, false),
+        ),
+        userRelationshipStorage.blockUser(userIds[0], userIds[2]),
+        userRelationshipStorage.blockUser(userIds[3], userIds[1]),
+      ]);
+      (
+        await Promise.allSettled([
+          request(app.getHttpServer())
+            .get(`/game/list/${gameId}`)
+            .set('x-user-id', spectatorOne.toString())
+            .expect(403),
+          request(app.getHttpServer())
+            .get(`/game/list/${gameId}`)
+            .set('x-user-id', spectatorTwo.toString())
+            .expect(403),
+        ])
+      ).forEach((result) => expect(result.status).toBe('fulfilled'));
+    });
+
+    it('should throw NOT FOUND if the game does not exist (404)', () => {
+      return request(app.getHttpServer())
+        .get(`/game/list/${nanoid()}`)
+        .set('x-user-id', userIds[0].toString())
+        .expect(404);
+    });
+  });
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : Game UI                                                         *
+   *                                                                           *
+   ****************************************************************************/
+});

--- a/backend/test/util/util.ts
+++ b/backend/test/util/util.ts
@@ -18,8 +18,8 @@ export async function timeout<T>(ms: number, promise: Promise<T>): Promise<T> {
   });
 }
 
-export const listenPromise = (socket: Socket, event: string) =>
-  new Promise((resolve) => socket.on(event, resolve));
+export const listenPromise = <T>(socket: Socket, event: string) =>
+  new Promise<T>((resolve) => socket.on(event, resolve));
 
 export const calculateLadderRise = (
   winnerLadder: number,


### PR DESCRIPTION
## 개요
- #139 완료
- queue timeout 은 다음 PR 에 추가하겠습니다.
- queue 코드가 조금 복잡해서 comment 로 최대한 설명해놓겠습니다. 그리고 notion 에 게임 관련 data flow 를 문서화할 예정입니다... 빠른 시일 내로...

## 작업 사항
- 아래 route 들 구현했습니다.
  - waitingRoom 에서 진행 중인 게임 array 를 얻기 위해 요청하는 `GET /game/list`.
  - waitingRoom/userComponent 에서 관전자가 게임방 UI 를 그리기 위해 필요한 정보를 요청하는 `GET /game/list/:gameId`.
  - ladder game 매칭 큐에 유저를 추가하는 `POST /game/queue`.
  - 플레이어가 게임방 그리는데 필요한 정보 요청하는 `GET /game/:gameId`
  - 일반 게임 map 변경하는 `PATCH /game/:gameId/options`.
  - 게임 동시 시작 trigger 하는 `PATCH /game/:gameId/start`.
- 플레이어들과 관전자에게 라이브 game 중개해주는 emitGameStatus 는 임시로 만들어뒀습니다.

## 변경점
- ladder 게임인지, 일반 게임인지 게임방 UI 에서 표시해주면 좋을 것 같아 해당 정보를 client 로 전달해주도록 `GET /game/list/:gameId`(관전자) & `GET /game/:gameId`(플레이어) res.body 를 수정했습니다. 
- ladder 게임의 경우 ui 에 들어가면 바로 실행되지만, 일반 게임의 경우 맵 설정 후 게임이 시작되어야하기 때문에 기존 설계대로 `GET /game/:gameId` 로 게임 시작을 trigger 할 수 없다고 판단하여 `PATCH /game/:gameId/start/` 를 새로 만들었습니다.

P.S. - PR 을 한번 분리했어야 했는데... 죄송합니다 ㅎㅎ

close #139