### PR TITLE
:sparkles: feat :  WS connection 인증하는 JwtAuthIoAdapter 구현

### DIFF
--- a/backend/src/auth/jwt-auth.io-adapter.ts
+++ b/backend/src/auth/jwt-auth.io-adapter.ts
@@ -1,5 +1,5 @@
-import { IoAdapter } from '@nestjs/platform-socket.io';
 import { INestApplication } from '@nestjs/common';
+import { IoAdapter } from '@nestjs/platform-socket.io';
 import { Server, ServerOptions } from 'socket.io';
 
 import {
@@ -21,7 +21,6 @@ export class JwtAuthIoAdapter extends IoAdapter {
   createIOServer(port: number, options?: ServerOptions) {
     options.cors = { origin: 'http://localhost:5173', credentials: true };
     options.allowRequest = this.allowRequest;
-
     const server: Server = super.createIOServer(port, options);
     server.engine.on('initial_headers', this.setCookies);
     return server;

--- a/backend/src/auth/jwt-auth.io-adapter.ts
+++ b/backend/src/auth/jwt-auth.io-adapter.ts
@@ -1,0 +1,96 @@
+import { IoAdapter } from '@nestjs/platform-socket.io';
+import { INestApplication } from '@nestjs/common';
+import { Server, ServerOptions } from 'socket.io';
+
+import {
+  ACCESS_TOKEN_COOKIE_OPTIONS,
+  REFRESH_TOKEN_COOKIE_OPTIONS,
+} from '../util/constant/cookie-constant';
+import { AuthService } from './auth.service';
+import { CookieOptions } from 'express';
+import { VerifiedWsRequest } from '../util/type';
+import { WEBSOCKET_CONFIG } from '../config/constant/constant-config';
+
+export class JwtAuthIoAdapter extends IoAdapter {
+  private authService: AuthService;
+  constructor(private app: INestApplication) {
+    super(app);
+    this.authService = this.app.get(AuthService);
+  }
+
+  createIOServer(port: number, options?: ServerOptions) {
+    options.cors = WEBSOCKET_CONFIG?.cors;
+    options.cookie = WEBSOCKET_CONFIG?.cookie;
+    options.allowRequest = this.allowRequest;
+
+    const server: Server = super.createIOServer(port, options);
+    server.engine.on('initial_headers', this.setCookies);
+    return server;
+  }
+
+  private allowRequest = async (
+    req: VerifiedWsRequest,
+    cb: (err: string | null, success: boolean) => void,
+  ) => {
+    const { accessToken, refreshToken } = this.findTokensFromCookie(
+      req.headers.cookie?.split('; '),
+    );
+    req.user = await this.verifyUser(accessToken, refreshToken);
+    if (req.user) {
+      cb(null, true);
+    } else {
+      cb('Unauthorized', false);
+    }
+  };
+
+  private async verifyUser(accessToken: string, refreshToken: string) {
+    let userId =
+      accessToken && this.authService.verifyAccessToken(accessToken)?.userId;
+    if (userId) {
+      return { userId };
+    }
+    userId =
+      refreshToken &&
+      (await this.authService.verifyRefreshToken(refreshToken))?.userId;
+    if (userId) {
+      const newTokens = await this.authService.issueTokens(userId);
+      return { userId, ...newTokens };
+    }
+    return null;
+  }
+
+  private findTokensFromCookie(cookies: string[]) {
+    if (!cookies) {
+      return {};
+    }
+    const accessToken = cookies
+      .find((row) => row.startsWith('accessToken='))
+      ?.split('=')[1];
+    const refreshToken = cookies
+      .find((row) => row.startsWith('refreshToken='))
+      ?.split('=')[1];
+    return { accessToken, refreshToken };
+  }
+
+  private setCookies = (headers: string[], req: VerifiedWsRequest) => {
+    if (req.user.accessToken) {
+      headers['Set-Cookie'].push([
+        this.setCookieValue(
+          `accessToken=${req.user.accessToken}`,
+          ACCESS_TOKEN_COOKIE_OPTIONS,
+        ),
+        this.setCookieValue(
+          `refreshToken=${req.user.refreshToken}`,
+          REFRESH_TOKEN_COOKIE_OPTIONS,
+        ),
+      ]);
+    }
+  };
+
+  private setCookieValue(value: string, option: CookieOptions) {
+    const { httpOnly, sameSite, secure, maxAge } = option;
+    return `${value}; Path=/${httpOnly && '; HttpOnly'}; SameSite=${sameSite}${
+      secure && '; Secure'
+    }; Max-Age=${maxAge}`;
+  }
+}

--- a/backend/src/auth/jwt-auth.io-adapter.ts
+++ b/backend/src/auth/jwt-auth.io-adapter.ts
@@ -19,6 +19,7 @@ export class JwtAuthIoAdapter extends IoAdapter {
   }
 
   createIOServer(port: number, options?: ServerOptions) {
+    options.cors = { origin: 'http://localhost:5173', credentials: true };
     options.allowRequest = this.allowRequest;
 
     const server: Server = super.createIOServer(port, options);
@@ -89,6 +90,6 @@ export class JwtAuthIoAdapter extends IoAdapter {
     const { httpOnly, sameSite, secure, maxAge } = option;
     return `${value}; Path=/${httpOnly && '; HttpOnly'}; SameSite=${sameSite}${
       secure && '; Secure'
-    }; Max-Age=${maxAge}`;
+    }; Max-Age=${maxAge / 1000}`;
   }
 }

--- a/backend/src/auth/jwt-auth.io-adapter.ts
+++ b/backend/src/auth/jwt-auth.io-adapter.ts
@@ -9,18 +9,16 @@ import {
 import { AuthService } from './auth.service';
 import { CookieOptions } from 'express';
 import { VerifiedWsRequest } from '../util/type';
-import { WEBSOCKET_CONFIG } from '../config/constant/constant-config';
 
 export class JwtAuthIoAdapter extends IoAdapter {
   private authService: AuthService;
+
   constructor(private app: INestApplication) {
     super(app);
     this.authService = this.app.get(AuthService);
   }
 
   createIOServer(port: number, options?: ServerOptions) {
-    options.cors = WEBSOCKET_CONFIG?.cors;
-    options.cookie = WEBSOCKET_CONFIG?.cookie;
     options.allowRequest = this.allowRequest;
 
     const server: Server = super.createIOServer(port, options);
@@ -74,7 +72,7 @@ export class JwtAuthIoAdapter extends IoAdapter {
 
   private setCookies = (headers: string[], req: VerifiedWsRequest) => {
     if (req.user.accessToken) {
-      headers['Set-Cookie'].push([
+      headers['set-cookie'] = [
         this.setCookieValue(
           `accessToken=${req.user.accessToken}`,
           ACCESS_TOKEN_COOKIE_OPTIONS,
@@ -83,7 +81,7 @@ export class JwtAuthIoAdapter extends IoAdapter {
           `refreshToken=${req.user.refreshToken}`,
           REFRESH_TOKEN_COOKIE_OPTIONS,
         ),
-      ]);
+      ];
     }
   };
 

--- a/backend/src/config/constant/constant-config.ts
+++ b/backend/src/config/constant/constant-config.ts
@@ -1,8 +1,7 @@
 export const WEBSOCKET_CONFIG =
   process.env.NODE_ENV === 'development'
     ? {
-        cors: { origin: 'http://localhost:5173' },
-        credentials: true,
+        cors: { origin: 'http://localhost:5173', credentials: true },
         cookie: true,
       }
     : {};

--- a/backend/src/config/constant/constant-config.ts
+++ b/backend/src/config/constant/constant-config.ts
@@ -2,6 +2,5 @@ export const WEBSOCKET_CONFIG =
   process.env.NODE_ENV === 'development'
     ? {
         cors: { origin: 'http://localhost:5173', credentials: true },
-        cookie: true,
       }
     : {};

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,12 +3,13 @@ import { NestFactory } from '@nestjs/core';
 import * as cookieParser from 'cookie-parser';
 
 import { AppModule } from './app.module';
+import { JwtAuthIoAdapter } from './auth/jwt-auth.io-adapter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  if (process.env.NODE_ENV === 'development') {
-    app.enableCors({ origin: 'http://localhost:5173', credentials: true });
-  }
+  process.env.NODE_ENV === 'production'
+    ? app.useWebSocketAdapter(new JwtAuthIoAdapter(app))
+    : app.enableCors({ origin: 'http://localhost:5173', credentials: true });
   app.use(cookieParser());
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -17,6 +17,7 @@ import {
   GameId,
   SocketId,
   UserId,
+  VerifiedSocket,
 } from '../util/type';
 import { ActivityManager } from './activity.manager';
 import { ChannelStorage } from './channel.storage';
@@ -66,14 +67,11 @@ export class ActivityGateway
    *
    * @param clientSocket connect 된 socket
    */
-  async handleConnection(clientSocket: Socket) {
-    // const accessToken = clientSocket.handshake.headers.cookie
-    //   .split(';')
-    //   .find((cookie) => cookie.includes('access_token='))
-    //   .replace('access_token=', '');
-    // const userId = this.authService.verifyAccessToken(accessToken).id;
-    // // NOTE : will throw error if token is invalid
-    const userId = Number(clientSocket.handshake.headers['x-user-id']);
+  async handleConnection(clientSocket: VerifiedSocket) {
+    const userId =
+      process.env.NODE_ENV === 'development'
+        ? Number(clientSocket.handshake.headers['x-user-id'])
+        : clientSocket.request.user.userId;
     const socketId = clientSocket.id;
     this.userSocketStorage.clients.set(userId, socketId);
     this.userSocketStorage.sockets.set(socketId, userId);

--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -1,5 +1,7 @@
 import { DateTime } from 'luxon';
 import { Request } from 'express';
+import { IncomingMessage } from 'http';
+import { Socket } from 'socket.io';
 
 export type UserId = number;
 
@@ -85,6 +87,14 @@ export interface VerifiedRequest extends Request {
 export interface RelationshipRequest extends VerifiedRequest {
   relationship: Relationship | null;
   targetId: UserId;
+}
+
+export interface VerifiedWsRequest extends IncomingMessage {
+  user: { userId: UserId; accessToken?: string; refreshToken?: string };
+}
+
+export interface VerifiedSocket extends Socket {
+  request: VerifiedWsRequest;
 }
 
 export interface RefreshTokenWrapper {

--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
-import { Request } from 'express';
 import { IncomingMessage } from 'http';
+import { Request } from 'express';
 import { Socket } from 'socket.io';
 
 export type UserId = number;

--- a/backend/test/activity-gateway.e2e-spec.ts
+++ b/backend/test/activity-gateway.e2e-spec.ts
@@ -11,6 +11,7 @@ import { UserStatusModule } from '../src/user-status/user-status.module';
 import { listenPromise } from './util/util';
 
 process.env.DB_HOST = 'localhost';
+process.env.NODE_ENV = 'development';
 
 const PORT = 4243;
 const URL = `http://localhost:${PORT}`;

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -10,6 +10,7 @@ import { Achievements } from '../src/entity/achievements.entity';
 import { Achievers } from '../src/entity/achievers.entity';
 import { AppModule } from '../src/app.module';
 import { AuthService } from '../src/auth/auth.service';
+import { JwtAuthIoAdapter } from '../src/auth/jwt-auth.io-adapter';
 import { MatchHistory } from '../src/entity/match-history.entity';
 import {
   TYPEORM_SHARED_CONFIG,
@@ -19,7 +20,6 @@ import {
 import { Users } from '../src/entity/users.entity';
 import { generateUsers } from './util/generate-mock-data';
 import { listenPromise } from './util/util';
-import { JwtAuthIoAdapter } from '../src/auth/jwt-auth.io-adapter';
 
 process.env.DB_HOST = 'localhost';
 process.env.NODE_ENV = 'production';

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -2,6 +2,7 @@ import { DataSource } from 'typeorm';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { io } from 'socket.io-client';
 import * as cookieParser from 'cookie-parser';
 import * as request from 'supertest';
 
@@ -17,13 +18,19 @@ import {
 } from './util/db-resource-manager';
 import { Users } from '../src/entity/users.entity';
 import { generateUsers } from './util/generate-mock-data';
+import { listenPromise } from './util/util';
+import { JwtAuthIoAdapter } from '../src/auth/jwt-auth.io-adapter';
+
+process.env.DB_HOST = 'localhost';
+process.env.NODE_ENV = 'production';
 
 const TEST_DB = 'test_db_auth_e2e';
 const ENTITIES = [Achievements, Achievers, MatchHistory, Users];
 
-process.env.DB_HOST = 'localhost';
+const PORT = 4252;
+const URL = `http://localhost:${PORT}`;
 
-describe('JwtAuthGuard (e2e)', () => {
+describe('Authentication Test (e2e)', () => {
   let app: INestApplication;
   let initDataSource: DataSource;
   let dataSource: DataSource;
@@ -49,6 +56,7 @@ describe('JwtAuthGuard (e2e)', () => {
       ],
     }).compile();
     app = moduleFixture.createNestApplication();
+    app.useWebSocketAdapter(new JwtAuthIoAdapter(app));
     app.useGlobalPipes(
       new ValidationPipe({
         forbidNonWhitelisted: true,
@@ -58,7 +66,7 @@ describe('JwtAuthGuard (e2e)', () => {
     );
     app.use(cookieParser());
     await app.init();
-    await app.listen(4252);
+    await app.listen(PORT);
     authService = app.get(AuthService);
   });
 
@@ -67,203 +75,272 @@ describe('JwtAuthGuard (e2e)', () => {
     await destroyDataSources(TEST_DB, dataSource, initDataSource);
   });
 
-  /**
-   * Synopsis No.1, Normal Case (Refresh Token Rotation)
-   * 1. 유저가 정상적으로 로그인 하여 access, refresh token 발급 받는다.
-   * 2. 유저의 access token 이 만료되고, 다시 요청을 보내면 refresh token 으로 재발급 받는다.
-   * 3. 유저의 refresh token 도 재발급 되어야 한다.
-   * 4. 서버엔 이전 refresh token (invalid)/ 새로 발급된 refresh token (valid) 이 저장되어 있어야 한다.
-   * 5. 재발급된 토큰으로 다시 로그인 할 수 있게 되며 1번으로 돌아간다.
-   */
-  it('Synopsis No.1, Normal Case', async () => {
-    const userId = usersEntities[0].userId;
-    // 1번
-    const { accessToken, refreshToken } = await authService.issueTokens(userId);
-    // 2번
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [
-        `accessToken=${accessToken}`,
-        `refreshToken=${refreshToken}`,
-      ])
-      .expect(200);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    // 3번
-    let newTokens;
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [`accessToken=${null}`, `refreshToken=${refreshToken}`])
-      .expect(200)
-      .expect(async (res) => {
-        newTokens = getToken(res);
-        expect(newTokens.accessToken).not.toBe(accessToken);
-        expect(newTokens.refreshToken).not.toBe(refreshToken);
-        const refreshTokens = await (authService as any).findRefreshTokens(
-          userId,
-        );
-        // 4번
-        expect(refreshTokens[0]).toEqual({
-          token: refreshToken,
-          isRevoked: true,
+  describe('HTTP Request', () => {
+    /**
+     * Synopsis No.1, Normal Case (Refresh Token Rotation)
+     * 1. 유저가 정상적으로 로그인 하여 access, refresh token 발급 받는다.
+     * 2. 유저의 access token 이 만료되고, 다시 요청을 보내면 refresh token 으로 재발급 받는다.
+     * 3. 유저의 refresh token 도 재발급 되어야 한다.
+     * 4. 서버엔 이전 refresh token (invalid)/ 새로 발급된 refresh token (valid) 이 저장되어 있어야 한다.
+     * 5. 재발급된 토큰으로 다시 로그인 할 수 있게 되며 1번으로 돌아간다.
+     */
+    it('Synopsis No.1, Normal Case', async () => {
+      const userId = usersEntities[0].userId;
+      // 1번
+      const { accessToken, refreshToken } = await authService.issueTokens(
+        userId,
+      );
+      // 2번
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [
+          `accessToken=${accessToken}`,
+          `refreshToken=${refreshToken}`,
+        ])
+        .expect(200);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // 3번
+      let newTokens;
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [`accessToken=${null}`, `refreshToken=${refreshToken}`])
+        .expect(200)
+        .expect(async (res) => {
+          newTokens = getToken(res);
+          expect(newTokens.accessToken).not.toBe(accessToken);
+          expect(newTokens.refreshToken).not.toBe(refreshToken);
+          const refreshTokens = await (authService as any).findRefreshTokens(
+            userId,
+          );
+          // 4번
+          expect(refreshTokens[0]).toEqual({
+            token: refreshToken,
+            isRevoked: true,
+          });
+          expect(refreshTokens[1]).toEqual({
+            token: newTokens.refreshToken,
+            isRevoked: false,
+          });
         });
-        expect(refreshTokens[1]).toEqual({
-          token: newTokens.refreshToken,
-          isRevoked: false,
+      // 5번
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [
+          `accessToken=${newTokens.accessToken}`,
+          `refreshToken=${newTokens.refreshToken}`,
+        ])
+        .expect(200);
+    });
+
+    /**
+     * Synopsis No.2 Expired Refresh Token
+     * 1. 유저가 정상적으로 로그인 하여 access, refresh token 발급 받는다.
+     * 2. 유저의 refresh token 이 만료되고, 다시 요청을 보내면 401 에러가 발생한다.
+     * 3. 유저는 재로그인 하여 토큰을 발급받고, 로그인이 가능해진다.
+     */
+    it('Synopsis No.2 Expired Refresh Token', async () => {
+      const userId = usersEntities[0].userId;
+      // 1번
+      const { accessToken, refreshToken } = await authService.issueTokens(
+        userId,
+      );
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [
+          `accessToken=${accessToken}`,
+          `refreshToken=${refreshToken}`,
+        ])
+        .expect(200);
+
+      // 2번
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [`accessToken=${null}`, `refreshToken=${null}`])
+        .expect(401);
+
+      // 3번
+      const newTokens = await authService.issueTokens(userId);
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [
+          `accessToken=${newTokens.accessToken}`,
+          `refreshToken=${newTokens.refreshToken}`,
+        ])
+        .expect(200);
+    });
+
+    /**
+     * Synopsis No.3-1, Automatic reuse detection (Malicious Client Take Over)
+     * @see [Automatic reuse detection](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation#automatic-reuse-detection)
+     * 1. 순진무구한(Legitimate user) 유저가 refreshToken_one 을 갖고 있지만, 이 토큰이 유출되거나 악의적인 유저에게 탈튀당했다.
+     * 2. 순진무구한 유저가 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급을 시도한다.
+     * 3. 서버는 새로운 access/refresh token 을 발급한다. (refreshToken_two)
+     * 4. 악의적인(Malicious) 유저가 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급을 시도한다.
+     * 5. 서버는 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급하지 않고, 401 에러를 발생시킨다.
+     *   5-1. 또한, 서버는 refreshToken_one 의 잘못된 사용을 탐지하고, refreshToken_one 과 refreshToken_two 를 모두 폐기한다.
+     * 6. 순진무구한 유저가 refreshToken_two 를 사용하려고 하면, 401 에러를 발생시켜 다시 로그인 시킨다.
+     */
+    it('Synopsis No.3-1, RefreshToken stolen, but Legitimate user use first', async () => {
+      const userId = usersEntities[2].userId;
+      const tokenOne = await authService.issueTokens(userId);
+      // 2번
+      let tokenTwo;
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [
+          `accessToken=${null}`,
+          `refreshToken=${tokenOne.refreshToken}`,
+        ])
+        .expect(200)
+        .expect(async (res) => {
+          // 3번
+          tokenTwo = getToken(res);
+        });
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // 4번
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [
+          `accessToken=${null}`,
+          `refreshToken=${tokenOne.refreshToken}`,
+        ])
+        // 5번
+        .expect(401)
+        .then(async () => {
+          // 5-1 번
+          const savedRefreshTokens = await (
+            authService as any
+          ).findRefreshTokens(userId);
+          expect(savedRefreshTokens[0].isRevoked).toBeTruthy();
+          expect(savedRefreshTokens[1].isRevoked).toBeTruthy();
+          // 6번
+          await request(app.getHttpServer())
+            .get(`/profile/${userId}`)
+            .set('Cookie', [
+              `accessToken=${null}`,
+              `refreshToken=${tokenTwo.refreshToken}`,
+            ])
+            .expect(401);
+        });
+    });
+
+    /**
+     * Synopsis No.3-2, Automatic reuse detection (Malicious Client Take Over)
+     * @see [Automatic reuse detection](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation#automatic-reuse-detection)
+     * 1. 순진무구한(Legitimate user) 유저가 refreshToken_one 을 갖고 있지만, 이 토큰이 유출되거나 악의적인 유저에게 탈튀당했다.
+     * 2. 악의적인(Malicious) 유저가 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급을 시도한다.
+     * 3. 서버는 새로운 access/refresh token 을 발급한다. (refreshToken_two)
+     * 4. 순진무구한 유저가 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급을 시도한다.
+     * 5. 서버는 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급하지 않고, 401 에러를 발생시킨다.
+     *   5-1. 또한, 서버는 refreshToken_one 의 잘못된 사용을 탐지하고, refreshToken_one 과 refreshToken_two 를 모두 폐기한다.
+     * 6. 악의적인 유저가 refreshToken_two 를 사용하려고 하면, 401 에러를 발생시켜 다시 로그인 시킨다.
+     */
+    it('Synopsis No.3-2, RefreshToken stolen, Malicious User use first', async () => {
+      const userId = usersEntities[2].userId;
+      const tokenOne = await authService.issueTokens(userId);
+      // 2번
+      let tokenTwo;
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [
+          `accessToken=${null}`,
+          `refreshToken=${tokenOne.refreshToken}`,
+        ])
+        .expect(200)
+        .expect(async (res) => {
+          // 3번
+          tokenTwo = getToken(res);
+        });
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // 4번
+      await request(app.getHttpServer())
+        .get(`/profile/${userId}`)
+        .set('Cookie', [
+          `accessToken=${null}`,
+          `refreshToken=${tokenOne.refreshToken}`,
+        ])
+        // 5번
+        .expect(401)
+        .then(async () => {
+          // 5-1 번
+          const savedRefreshTokens = await (
+            authService as any
+          ).findRefreshTokens(userId);
+          expect(savedRefreshTokens[0].isRevoked).toBeTruthy();
+          expect(savedRefreshTokens[1].isRevoked).toBeTruthy();
+          // 6번
+          await request(app.getHttpServer())
+            .get(`/profile/${userId}`)
+            .set('Cookie', [
+              `accessToken=${null}`,
+              `refreshToken=${tokenTwo.refreshToken}`,
+            ])
+            .expect(401);
+        });
+    });
+  });
+
+  describe('WS Event', () => {
+    it('should connect to WS with valid tokens', async () => {
+      const { accessToken, refreshToken } = await authService.issueTokens(
+        usersEntities[0].userId,
+      );
+      const clientSocket = io(URL, {
+        extraHeaders: {
+          Cookie: `accessToken=${accessToken}; refreshToken=${refreshToken}`,
+        },
+      });
+      await listenPromise(clientSocket, 'connect');
+      expect(clientSocket.connected).toBeTruthy();
+
+      clientSocket.close();
+    });
+
+    it('should connect to WS with valid accessToken', async () => {
+      const { accessToken } = await authService.issueTokens(
+        usersEntities[1].userId,
+      );
+      const clientSocket = io(URL, {
+        extraHeaders: {
+          Cookie: `accessToken=${accessToken}`,
+        },
+      });
+      await listenPromise(clientSocket, 'connect');
+      expect(clientSocket.connected).toBeTruthy();
+
+      clientSocket.close();
+    });
+
+    it('should connect to WS with valid refreshToken', async () => {
+      const { refreshToken } = await authService.issueTokens(
+        usersEntities[2].userId,
+      );
+      const clientSocket = io(URL, {
+        extraHeaders: {
+          Cookie: `refreshToken=${refreshToken}`,
+        },
+      });
+      await listenPromise(clientSocket, 'connect');
+      expect(clientSocket.connected).toBeTruthy();
+      clientSocket.close();
+    });
+
+    it('should not connect to WS with invalid refreshToken', async () => {
+      const clientSocket = io(URL, {
+        extraHeaders: {
+          Cookie: `refreshToken=hi0this1is2trash3.jwt4mocking5refresh6token.this7section9is10secret11generated5by6key`,
+        },
+      });
+      await new Promise<Error>((resolve) => {
+        clientSocket.io.on('error', (err) => {
+          expect((err as any).description).toBe(403);
+          const res = (err as any).context.responseText;
+          expect(JSON.parse(res).message).toBe('Unauthorized');
+          resolve(err);
+          clientSocket.close();
         });
       });
-    // 5번
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [
-        `accessToken=${newTokens.accessToken}`,
-        `refreshToken=${newTokens.refreshToken}`,
-      ])
-      .expect(200);
-  });
-
-  /**
-   * Synopsis No.2 Expired Refresh Token
-   * 1. 유저가 정상적으로 로그인 하여 access, refresh token 발급 받는다.
-   * 2. 유저의 refresh token 이 만료되고, 다시 요청을 보내면 401 에러가 발생한다.
-   * 3. 유저는 재로그인 하여 토큰을 발급받고, 로그인이 가능해진다.
-   */
-  it('Synopsis No.2 Expired Refresh Token', async () => {
-    const userId = usersEntities[0].userId;
-    // 1번
-    const { accessToken, refreshToken } = await authService.issueTokens(userId);
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [
-        `accessToken=${accessToken}`,
-        `refreshToken=${refreshToken}`,
-      ])
-      .expect(200);
-
-    // 2번
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [`accessToken=${null}`, `refreshToken=${null}`])
-      .expect(401);
-
-    // 3번
-    const newTokens = await authService.issueTokens(userId);
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [
-        `accessToken=${newTokens.accessToken}`,
-        `refreshToken=${newTokens.refreshToken}`,
-      ])
-      .expect(200);
-  });
-
-  /**
-   * Synopsis No.3-1, Automatic reuse detection (Malicious Client Take Over)
-   * @see [Automatic reuse detection](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation#automatic-reuse-detection)
-   * 1. 순진무구한(Legitimate user) 유저가 refreshToken_one 을 갖고 있지만, 이 토큰이 유출되거나 악의적인 유저에게 탈튀당했다.
-   * 2. 순진무구한 유저가 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급을 시도한다.
-   * 3. 서버는 새로운 access/refresh token 을 발급한다. (refreshToken_two)
-   * 4. 악의적인(Malicious) 유저가 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급을 시도한다.
-   * 5. 서버는 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급하지 않고, 401 에러를 발생시킨다.
-   *   5-1. 또한, 서버는 refreshToken_one 의 잘못된 사용을 탐지하고, refreshToken_one 과 refreshToken_two 를 모두 폐기한다.
-   * 6. 순진무구한 유저가 refreshToken_two 를 사용하려고 하면, 401 에러를 발생시켜 다시 로그인 시킨다.
-   */
-  it('Synopsis No.3-1, RefreshToken stolen, but Legitimate user use first', async () => {
-    const userId = usersEntities[2].userId;
-    const tokenOne = await authService.issueTokens(userId);
-    // 2번
-    let tokenTwo;
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [
-        `accessToken=${null}`,
-        `refreshToken=${tokenOne.refreshToken}`,
-      ])
-      .expect(200)
-      .expect(async (res) => {
-        // 3번
-        tokenTwo = getToken(res);
-      });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    // 4번
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [
-        `accessToken=${null}`,
-        `refreshToken=${tokenOne.refreshToken}`,
-      ])
-      // 5번
-      .expect(401)
-      .then(async () => {
-        // 5-1 번
-        const savedRefreshTokens = await (authService as any).findRefreshTokens(
-          userId,
-        );
-        expect(savedRefreshTokens[0].isRevoked).toBeTruthy();
-        expect(savedRefreshTokens[1].isRevoked).toBeTruthy();
-        // 6번
-        await request(app.getHttpServer())
-          .get(`/profile/${userId}`)
-          .set('Cookie', [
-            `accessToken=${null}`,
-            `refreshToken=${tokenTwo.refreshToken}`,
-          ])
-          .expect(401);
-      });
-  });
-
-  /**
-   * Synopsis No.3-2, Automatic reuse detection (Malicious Client Take Over)
-   * @see [Automatic reuse detection](https://auth0.com/docs/secure/tokens/refresh-tokens/refresh-token-rotation#automatic-reuse-detection)
-   * 1. 순진무구한(Legitimate user) 유저가 refreshToken_one 을 갖고 있지만, 이 토큰이 유출되거나 악의적인 유저에게 탈튀당했다.
-   * 2. 악의적인(Malicious) 유저가 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급을 시도한다.
-   * 3. 서버는 새로운 access/refresh token 을 발급한다. (refreshToken_two)
-   * 4. 순진무구한 유저가 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급을 시도한다.
-   * 5. 서버는 refreshToken_one 을 사용하여 새로운 access/refresh token 을 발급하지 않고, 401 에러를 발생시킨다.
-   *   5-1. 또한, 서버는 refreshToken_one 의 잘못된 사용을 탐지하고, refreshToken_one 과 refreshToken_two 를 모두 폐기한다.
-   * 6. 악의적인 유저가 refreshToken_two 를 사용하려고 하면, 401 에러를 발생시켜 다시 로그인 시킨다.
-   */
-  it('Synopsis No.3-2, RefreshToken stolen, Malicious User use first', async () => {
-    const userId = usersEntities[2].userId;
-    const tokenOne = await authService.issueTokens(userId);
-    // 2번
-    let tokenTwo;
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [
-        `accessToken=${null}`,
-        `refreshToken=${tokenOne.refreshToken}`,
-      ])
-      .expect(200)
-      .expect(async (res) => {
-        // 3번
-        tokenTwo = getToken(res);
-      });
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    // 4번
-    await request(app.getHttpServer())
-      .get(`/profile/${userId}`)
-      .set('Cookie', [
-        `accessToken=${null}`,
-        `refreshToken=${tokenOne.refreshToken}`,
-      ])
-      // 5번
-      .expect(401)
-      .then(async () => {
-        // 5-1 번
-        const savedRefreshTokens = await (authService as any).findRefreshTokens(
-          userId,
-        );
-        expect(savedRefreshTokens[0].isRevoked).toBeTruthy();
-        expect(savedRefreshTokens[1].isRevoked).toBeTruthy();
-        // 6번
-        await request(app.getHttpServer())
-          .get(`/profile/${userId}`)
-          .set('Cookie', [
-            `accessToken=${null}`,
-            `refreshToken=${tokenTwo.refreshToken}`,
-          ])
-          .expect(401);
-      });
+    });
   });
 });
 

--- a/backend/test/chats-gateway.e2e-spec.ts
+++ b/backend/test/chats-gateway.e2e-spec.ts
@@ -23,6 +23,7 @@ import {
 import { timeout } from './util/util';
 
 process.env.DB_HOST = 'localhost';
+process.env.NODE_ENV = 'development';
 
 const PORT = 4245;
 const URL = `http://localhost:${PORT}`;


### PR DESCRIPTION
## 개요
- #62 완료
## 작업 사항
- WebSocket 에서 access / refresh 토큰 인증
## 변경점
- 인증과정에 필요한 타입 추가 (VerifiedWsRequest, VerifiedSocket)
- 인증 실패시 client 에서 다음과 같이 핸들링 하면 될 것 같습니다.
```tsx
  const nav = useNavigate();
  const socket = io('http://localhost:3000', { withCredentials: true }); // socket 연결 시 자동으로 서버에서 인증 실행

  socket.io.on('error', (error: any) => {
     alert('connect_error'); // error message
     socket.close();
     nav('/login'); // 로그인 페이지로 redirect
  });
```
- WEBSOCKET_CONFIG 에 cookie 옵션 삭제
  - 서버가 1개인 경우는 필요 없다고 나와 있어서 삭제했습니다 [socket.io 설명](https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#no-more-cookie-by-default)

---
- `backend/test/auth.e2e-spec.ts` 파일에 diff 가 너무 많이 뜨는데, 실제로 추가된 부분은 283번 라인 이후입니다.
