### PR TITLE
:hammer: chore : color 변수화 & x-user-id env 로 적용

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,0 +1,1 @@
+VITE_X_USER_ID=

--- a/frontend/src/style/App.css
+++ b/frontend/src/style/App.css
@@ -8,18 +8,19 @@
 }
 
 header {
-  background-color: lightgrey;
+  background-color: var(--primary_light);
 }
 
 nav {
-  background-color: #339999;
+  background-color: var(--secondary);
+  color: var(--primary_dark);
   grid-row: 1 / 3;
   grid-column: 1 / 2;
 }
 
 main {
-  /* align-items: center; */
-  background-color: lightcoral;
+  align-items: center;
+  background-color: var(--primary_light);
   display: grid;
-  /* justify-items: center; */
+  justify-items: center;
 }

--- a/frontend/src/style/GameRoom.css
+++ b/frontend/src/style/GameRoom.css
@@ -5,7 +5,6 @@
   display: grid;
   grid-template-rows: 15% 1fr 10%;
   min-width: 640px;
-  place-self: center;
   width: 56%;
 }
 

--- a/frontend/src/style/index.css
+++ b/frontend/src/style/index.css
@@ -1,3 +1,4 @@
+@import './presets/color.css';
 @import './presets/font.css';
 @import './presets/reset.css';
 @import './App.css';

--- a/frontend/src/style/presets/color.css
+++ b/frontend/src/style/presets/color.css
@@ -1,0 +1,8 @@
+:root {
+  --primary: #6a7ba2;
+  --primary_light: #99aad3;
+  --primary_dark: #3d4f73;
+  --secondary: #ffdfde;
+  --secondary_light: #fff;
+  --secondary_dark: #ccadac;
+}

--- a/frontend/src/util/Axios.ts
+++ b/frontend/src/util/Axios.ts
@@ -3,7 +3,8 @@ import axios from 'axios';
 const instance = axios.create({
   baseURL: 'http://localhost:3000',
 });
+
 // FIXME : x-user-id 보내기
-instance.defaults.headers.common['x-user-id'] = 20834;
+instance.defaults.headers.common['x-user-id'] = import.meta.env.VITE_X_USER_ID;
 
 export default instance;

--- a/frontend/src/util/Socket.ts
+++ b/frontend/src/util/Socket.ts
@@ -2,7 +2,7 @@ import io from 'socket.io-client';
 
 const socket = io('http://localhost:3000', {
   extraHeaders: {
-    'x-user-id': '20834',
+    'x-user-id': import.meta.env.VITE_X_USER_ID,
   },
   withCredentials: true,
 });


### PR DESCRIPTION
## 개요
- #171 완료
- color 값들 변수화했습니다. `var(변수명)` 으로 CSS 에서 사용하시면 됩니다.
- `frontend/.env` 파일 만드시고 `VITE_X_USER_ID` 변수에 사용하고자 하시는 userId 넣어서 사용하시면 됩니다. .env Vite 가 다 해주더라고요! 원하면 MODE 별로 나눌 수 있는데 굳이 그럴 필요가 없다고 판단했습니다. env variable 추가해서 사용하고 싶으시면 `VITE_` prefix 를 꼭 붙여주셔야합니다. 해당 prefix 가 있는 변수들만 `import.meta.env.변수명` 으로 script 로 접근 가능합니다. 궁금하시면 이 [링크](https://vitejs.dev/guide/env-and-mode.html) 참조하세요 :)

close #171 