### PR TITLE
✨ feat : 서비스 미접속 기간 동안 받은 친구 요청 전달

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,7 +9,11 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   process.env.NODE_ENV === 'production'
     ? app.useWebSocketAdapter(new JwtAuthIoAdapter(app))
-    : app.enableCors({ origin: 'http://localhost:5173', credentials: true });
+    : app.enableCors({
+        exposedHeaders: 'location',
+        credentials: true,
+        origin: 'http://localhost:5173',
+      });
   app.use(cookieParser());
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -10,8 +10,8 @@ async function bootstrap() {
   process.env.NODE_ENV === 'production'
     ? app.useWebSocketAdapter(new JwtAuthIoAdapter(app))
     : app.enableCors({
-        exposedHeaders: 'location',
         credentials: true,
+        exposedHeaders: 'location',
         origin: 'http://localhost:5173',
       });
   app.use(cookieParser());

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -27,6 +27,7 @@ import { GameGateway } from '../game/game.gateway';
 import { GameStorage } from '../game/game.storage';
 import { RanksGateway } from '../ranks/ranks.gateway';
 import { UserActivityDto } from './dto/user-status.dto';
+import { UserGateway } from '../user/user.gateway';
 import { UserRelationshipStorage } from './user-relationship.storage';
 import { UserSocketStorage } from './user-socket.storage';
 import { WEBSOCKET_CONFIG } from '../config/constant/constant-config';
@@ -52,6 +53,7 @@ export class ActivityGateway
     private readonly gameGateway: GameGateway,
     private readonly gameStorage: GameStorage,
     private readonly ranksGateway: RanksGateway,
+    private readonly userGateway: UserGateway,
     private readonly userRelationshipStorage: UserRelationshipStorage,
     private readonly userSocketStorage: UserSocketStorage,
   ) {}
@@ -85,6 +87,10 @@ export class ActivityGateway
         this.chatsGateway.joinChannelRoom(channelId, userId);
       }
     }
+    this.userGateway.emitFriendRequestDiff(
+      socketId,
+      this.userRelationshipStorage.countPendingRequests(userId),
+    );
     clientSocket.on('disconnecting', () =>
       this.handleDisconnecting(clientSocket.id, clientSocket.rooms),
     );

--- a/backend/src/user-status/user-relationship.storage.spec.ts
+++ b/backend/src/user-status/user-relationship.storage.spec.ts
@@ -395,4 +395,17 @@ describe('UserRelationshipService', () => {
       ).length,
     ).toBe(0);
   });
+
+  it('should count the number of pending friend requests', async () => {
+    const receiverId = usersPool[2][0].userId;
+    for (let i = 1; i < usersPool[2].length; i++) {
+      const senderId = usersPool[2][i].userId;
+      await userRelationshipStorage.load(senderId);
+      await userRelationshipStorage.sendFriendRequest(senderId, receiverId);
+    }
+    await userRelationshipStorage.load(receiverId);
+    expect(userRelationshipStorage.countPendingRequests(receiverId)).toBe(
+      usersPool[2].length - 1,
+    );
+  });
 });

--- a/backend/src/user-status/user-relationship.storage.ts
+++ b/backend/src/user-status/user-relationship.storage.ts
@@ -304,6 +304,20 @@ export class UserRelationshipStorage implements OnModuleInit {
     this.users.get(to)?.delete(from);
   }
 
+  /**
+   * @description 받은 친구 요청 개수 반환
+   *
+   * @param userId 유저 id
+   * @returns 받은 친구 요청 개수
+   */
+  countPendingRequests(userId: UserId) {
+    let count = 0;
+    this.users
+      .get(userId)
+      .forEach((status) => status === 'pendingReceiver' && count++);
+    return count;
+  }
+
   /*****************************************************************************
    *                                                                           *
    * NOTE : TEST ONLY                                                          *

--- a/backend/src/user-status/user-status.module.ts
+++ b/backend/src/user-status/user-status.module.ts
@@ -14,6 +14,7 @@ import { GameModule } from '../game/game.module';
 import { MatchHistory } from '../entity/match-history.entity';
 import { Messages } from '../entity/messages.entity';
 import { RanksModule } from '../ranks/ranks.module';
+import { UserModule } from './../user/user.module';
 import { UserRelationshipStorage } from './user-relationship.storage';
 import { UserSocketStorage } from './user-socket.storage';
 import { Users } from '../entity/users.entity';
@@ -30,9 +31,10 @@ import { Users } from '../entity/users.entity';
       Messages,
       Users,
     ]),
+    RanksModule,
     forwardRef(() => ChatsModule),
     forwardRef(() => GameModule),
-    RanksModule,
+    forwardRef(() => UserModule),
   ],
   providers: [
     ActivityGateway,

--- a/backend/src/user/user.gateway.ts
+++ b/backend/src/user/user.gateway.ts
@@ -15,7 +15,7 @@ export class UserGateway {
    * @param receiverSocketId
    * @param requestDiff
    */
-  emitFriendRequestDiff(receiverSocketId: SocketId, requestDiff: 1 | -1) {
+  emitFriendRequestDiff(receiverSocketId: SocketId, requestDiff: number) {
     this.server.to(receiverSocketId).emit('friendRequestDiff', { requestDiff });
   }
 

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { GameModule } from '../game/game.module';
@@ -9,8 +9,13 @@ import { UserStatusModule } from '../user-status/user-status.module';
 import { Users } from '../entity/users.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Users]), GameModule, UserStatusModule],
+  imports: [
+    TypeOrmModule.forFeature([Users]),
+    GameModule,
+    forwardRef(() => UserStatusModule),
+  ],
   controllers: [UserController],
   providers: [UserGateway, UserService],
+  exports: [UserGateway],
 })
 export class UserModule {}

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -90,7 +90,7 @@ describe('UserService', () => {
           userId: UserId,
           relationship: Relationship | 'normal',
         ) => undefined,
-        emitFriendRequestDiff: (socketId: SocketId, requestDiff: 1 | -1) =>
+        emitFriendRequestDiff: (socketId: SocketId, requestDiff: number) =>
           undefined,
       })
       .overrideProvider(ActivityGateway)


### PR DESCRIPTION
## 개요
- #164 완료
  - 이제 e2e 테스트 한꺼번에 돌리면 간간히 터집니다. 하나씩 돌리면 다 괜찮습니다. 다 하나씩 돌렸봤습니다...
- #176 완료

## 변경 사항
- 유저 WS connection 시 받은 친구요청 개수 `friendRequestDiff` 로 전송.
- 개발 환경일 경우 Access-Control-Expose-Headers 에 'location' 헤더 필드 더하여서 CORS 여도 클라이언트가 해당 헤더 필드 접근 가능하게 설정.

close #164
close #176
