### PR TITLE
✨ feat : 유저 컴포넌트를 보고 있는 유저에게만 activity 변경 정보 전달 #165

### DIFF
--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -274,6 +274,7 @@ export class ActivityGateway
         .forEach((watchedUserId) =>
           this.server.in(socketId).socketsLeave(`activity-${watchedUserId}`),
         );
+      this.activityManager.deleteWatchingUser(prevUi, userId);
     }
   }
 

--- a/backend/src/user-status/activity.manager.spec.ts
+++ b/backend/src/user-status/activity.manager.spec.ts
@@ -62,6 +62,45 @@ describe('ActivityService', () => {
     expect(manager.getWatchedUsers('profile', userId)).toEqual(
       usersEntities.slice(1, 10).map(({ userId }) => userId),
     );
-    // manager.deleteWatchingUser
+    manager.deleteWatchingUser('profile', userId);
+    expect(manager.getWatchedUsers('profile', userId)).toEqual([]);
+  });
+
+  it('should return an array of watched users by a user for a specific ui', () => {
+    const [{ userId: userOneId }, { userId: userTwoId }] = usersEntities;
+
+    for (let i = 1; i < 10; i++) {
+      manager.setWatchingUser('profile', usersEntities[i].userId, userOneId);
+    }
+    for (let i = 10; i < 20; i++) {
+      manager.setWatchingUser('chats', usersEntities[i].userId, userTwoId);
+    }
+    expect(manager.getWatchedUsers('profile', userOneId)).toEqual(
+      usersEntities.slice(1, 10).map(({ userId }) => userId),
+    );
+    expect(manager.getWatchedUsers('chats', userTwoId)).toEqual(
+      usersEntities.slice(10, 20).map(({ userId }) => userId),
+    );
+    manager.deleteWatchingUser('profile', userOneId);
+    manager.deleteWatchingUser('chats', userTwoId);
+    expect(manager.getWatchedUsers('profile', userOneId)).toEqual([]);
+    expect(manager.getWatchedUsers('chats', userTwoId)).toEqual([]);
+  });
+
+  it('should return an empty array if no users are being watched by a user looking at friends list toggle', () => {
+    const { userId } = usersEntities[0];
+    expect(manager.getFriendWatchedUsers(userId)).toEqual([]);
+  });
+
+  it('should return an array of watched users by a user looking at friends list toggle', () => {
+    const { userId } = usersEntities[0];
+    for (let i = 1; i < 10; i++) {
+      manager.setFriendWatchingUser(usersEntities[i].userId, userId);
+    }
+    expect(manager.getFriendWatchedUsers(userId)).toEqual(
+      usersEntities.slice(1, 10).map(({ userId }) => userId),
+    );
+    manager.deleteFriendWatchingUser(userId);
+    expect(manager.getFriendWatchedUsers(userId)).toEqual([]);
   });
 });

--- a/backend/src/user-status/activity.manager.spec.ts
+++ b/backend/src/user-status/activity.manager.spec.ts
@@ -41,4 +41,27 @@ describe('ActivityService', () => {
     manager.deleteActivity(userId);
     expect(manager.getActivity(userId)).toBeNull();
   });
+
+  /*****************************************************************************
+   *                                                                           *
+   * SECTION : watchedUsers                                                    *
+   *                                                                           *
+   ****************************************************************************/
+
+  it('should return an empty array if no users are being watched', () => {
+    const { userId } = usersEntities[0];
+    expect(manager.getWatchedUsers('profile', userId)).toEqual([]);
+  });
+
+  it('should return an array of watched users by a user', () => {
+    const { userId } = usersEntities[0];
+
+    for (let i = 1; i < 10; i++) {
+      manager.setWatchingUser('profile', usersEntities[i].userId, userId);
+    }
+    expect(manager.getWatchedUsers('profile', userId)).toEqual(
+      usersEntities.slice(1, 10).map(({ userId }) => userId),
+    );
+    // manager.deleteWatchingUser
+  });
 });

--- a/backend/src/user-status/activity.manager.ts
+++ b/backend/src/user-status/activity.manager.ts
@@ -4,6 +4,7 @@ import { CurrentUi, UserId } from '../util/type';
 
 @Injectable()
 export class ActivityManager {
+  readonly friendListOpenedBy: Set<UserId> = new Set();
   private readonly userActivity: Map<UserId, CurrentUi> = new Map();
   private readonly watchers: Map<CurrentUi, Map<UserId, Set<UserId>>> =
     new Map();

--- a/backend/src/user-status/activity.manager.ts
+++ b/backend/src/user-status/activity.manager.ts
@@ -4,7 +4,10 @@ import { CurrentUi, UserId } from '../util/type';
 
 @Injectable()
 export class ActivityManager {
-  private userActivity: Map<UserId, CurrentUi> = new Map();
+  private readonly userActivity: Map<UserId, CurrentUi> = new Map();
+  private readonly watchers: Map<CurrentUi, Map<UserId, Set<UserId>>> =
+    new Map();
+  private readonly friendWatchers: Map<UserId, Set<UserId>> = new Map();
 
   getActivity(userId: UserId) {
     return this.userActivity.get(userId) ?? null;
@@ -16,5 +19,63 @@ export class ActivityManager {
 
   deleteActivity(userId: UserId) {
     this.userActivity.delete(userId);
+  }
+
+  getWatchedUsers(ui: CurrentUi, watcherId: UserId) {
+    const watchedMap = this.watchers.get(ui);
+    if (watchedMap === undefined) return [];
+    const watchedUsers = [];
+    for (const [watchedId, watcherSet] of watchedMap) {
+      watcherSet.has(watcherId) && watchedUsers.push(watchedId);
+    }
+    return watchedUsers;
+  }
+
+  setWatchingUser(ui: CurrentUi, watchedId: UserId, watcherId: UserId) {
+    const watchedMap = this.watchers.get(ui);
+    if (watchedMap === undefined) {
+      this.watchers.set(ui, new Map([[watchedId, new Set([watcherId])]]));
+      return;
+    }
+    const watcherSet = watchedMap.get(watchedId);
+    if (watcherSet === undefined) {
+      watchedMap.set(watchedId, new Set([watcherId]));
+      return;
+    }
+    watcherSet.add(watcherId);
+  }
+
+  deleteWatchingUser(ui: CurrentUi, watcherId: UserId) {
+    const watchedMap = this.watchers.get(ui);
+    if (watchedMap === undefined) {
+      return;
+    }
+    for (const [watchedId, watcherSet] of watchedMap) {
+      watcherSet.delete(watcherId);
+      watcherSet.size === 0 && watchedMap.delete(watchedId);
+    }
+    watchedMap.size === 0 && this.watchers.delete(ui);
+  }
+
+  getFriendWatchedUsers(watcherId: UserId) {
+    const watchedUsers = [];
+    for (const [watchedId, watcherSet] of this.friendWatchers) {
+      watcherSet.has(watcherId) && watchedUsers.push(watchedId);
+    }
+    return watchedUsers;
+  }
+
+  setFriendWatchingUser(watchedId: UserId, watcherId: UserId) {
+    const watcherSet = this.friendWatchers.get(watchedId);
+    watcherSet === undefined
+      ? this.friendWatchers.set(watchedId, new Set([watcherId]))
+      : watcherSet.add(watcherId);
+  }
+
+  deleteFriendWatchingUser(watcherId: UserId) {
+    for (const [watchedId, watcherSet] of this.friendWatchers) {
+      watcherSet.delete(watcherId);
+      watcherSet.size === 0 && this.friendWatchers.delete(watchedId);
+    }
   }
 }

--- a/backend/src/user-status/activity.manager.ts
+++ b/backend/src/user-status/activity.manager.ts
@@ -21,6 +21,13 @@ export class ActivityManager {
     this.userActivity.delete(userId);
   }
 
+  /**
+   * @description 특정 UI 에서 특정 유저가 보고 있는 유저 컴포넌트들의 유저 ID 반환
+   *
+   * @param ui 특정 UI
+   * @param watcherId 유저 컴포넌트들을 보고 있는 유저의 ID
+   * @returns 보여지고 있는 유저들의 ID
+   */
   getWatchedUsers(ui: CurrentUi, watcherId: UserId) {
     const watchedMap = this.watchers.get(ui);
     if (watchedMap === undefined) return [];
@@ -31,6 +38,14 @@ export class ActivityManager {
     return watchedUsers;
   }
 
+  /**
+   * @description 특정 UI 에서 어떤 유저가 특정 유저의 유저 컴포넌트를 보는 경우
+   *              보여 지고 있는 유저 컴포넌트의 유저를 보고 있는 유저들 목록에 추가
+   *
+   * @param ui 특정 UI
+   * @param watchedId 보여지고 있는 유저 컴포넌트의 유저 ID
+   * @param watcherId 보고 있는 유저의 ID
+   */
   setWatchingUser(ui: CurrentUi, watchedId: UserId, watcherId: UserId) {
     const watchedMap = this.watchers.get(ui);
     if (watchedMap === undefined) {
@@ -45,6 +60,13 @@ export class ActivityManager {
     watcherSet.add(watcherId);
   }
 
+  /**
+   * @description 유저가 특정 UI 를 떠날 때, 떠나는 유저를 유저 컴포넌트가 보여 지고 있는
+   *              유저들을 보고 있는 유저들 목록에서 삭제
+   *
+   * @param ui 특정 UI
+   * @param watcherId 떠나는 유저의 ID
+   */
   deleteWatchingUser(ui: CurrentUi, watcherId: UserId) {
     const watchedMap = this.watchers.get(ui);
     if (watchedMap === undefined) {
@@ -57,6 +79,12 @@ export class ActivityManager {
     watchedMap.size === 0 && this.watchers.delete(ui);
   }
 
+  /**
+   * @description 친구 토글 리스트를 보고 있는 유저가 보고 있는 유저 컴포넌트들의 유저 ID 반환
+   *
+   * @param watcherId 유저 컴포넌트들을 보고 있는 유저의 ID
+   * @returns 보여지고 있는 유저들의 ID
+   */
   getFriendWatchedUsers(watcherId: UserId) {
     const watchedUsers = [];
     for (const [watchedId, watcherSet] of this.friendWatchers) {
@@ -65,6 +93,13 @@ export class ActivityManager {
     return watchedUsers;
   }
 
+  /**
+   * @description 친구 토글 리스트를 보고 있는 유저가 특정 유저의 유저 컴포넌트를 보는 경우
+   *              보여 지고 있는 유저 컴포넌트의 유저를 보고 있는 유저들 목록에 추가
+   *
+   * @param watchedId 보여지고 있는 유저 컴포넌트의 유저 ID
+   * @param watcherId 보고 있는 유저의 ID
+   */
   setFriendWatchingUser(watchedId: UserId, watcherId: UserId) {
     const watcherSet = this.friendWatchers.get(watchedId);
     watcherSet === undefined
@@ -72,6 +107,11 @@ export class ActivityManager {
       : watcherSet.add(watcherId);
   }
 
+  /**
+   * @description 유저가 친구 토글 리스트를 닫을 때, 떠나는 유저를 유저 컴포넌트가 보여 지고 있는
+   *              유저들을 보고 있는 유저들 목록에서 삭제
+   * @param watcherId 떠나는 유저의 ID
+   */
   deleteFriendWatchingUser(watcherId: UserId) {
     for (const [watchedId, watcherSet] of this.friendWatchers) {
       watcherSet.delete(watcherId);

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -94,7 +94,14 @@ describe('UserService', () => {
           undefined,
       })
       .overrideProvider(ActivityGateway)
-      .useValue({ emitUserActivity: (targetId: UserId) => undefined })
+      .useValue({
+        emitUserActivity: (targetId: UserId) => undefined,
+        joinActivityRoom: (
+          socketId: SocketId,
+          requesterId: UserId,
+          targetId: UserId,
+        ) => undefined,
+      })
       .compile();
 
     await module.init();
@@ -142,11 +149,13 @@ describe('UserService', () => {
       const spies = [
         jest.spyOn(userGateway, 'emitUserRelationship'),
         jest.spyOn(activityGateway, 'emitUserActivity'),
+        jest.spyOn(activityGateway, 'joinActivityRoom'),
       ];
       const [requesterId, targetId] = userIds;
       await service.findProfile(requesterId, targetId);
       expect(spies[0]).toHaveBeenCalled();
       expect(spies[1]).toHaveBeenCalled();
+      expect(spies[2]).toHaveBeenCalled();
     });
   });
 

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -23,9 +23,9 @@ export class UserService {
     private readonly channelStorage: ChannelStorage,
     private readonly userGateway: UserGateway,
     private readonly userRelationshipStorage: UserRelationshipStorage,
-    private readonly userSocketStorage: UserSocketStorage,
     @InjectRepository(Users)
     private readonly usersRepository: Repository<Users>,
+    private readonly userSocketStorage: UserSocketStorage,
   ) {}
 
   /*****************************************************************************
@@ -237,6 +237,11 @@ export class UserService {
     }
     const requesterSocketId = this.userSocketStorage.clients.get(requesterId);
     if (requesterSocketId !== undefined) {
+      this.activityGateway.joinActivityRoom(
+        requesterSocketId,
+        requesterId,
+        targetId,
+      );
       this.activityGateway.emitUserActivity(targetId);
       this.userGateway.emitUserRelationship(
         requesterSocketId,

--- a/backend/test/activity-gateway.e2e-spec.ts
+++ b/backend/test/activity-gateway.e2e-spec.ts
@@ -87,7 +87,11 @@ describe('UserStatusModule (e2e)', () => {
    *                                                                           *
    ****************************************************************************/
 
-  describe('userActivity (WS)', () => {
+  /** NOTE : userActivity 가 GET /user/:userId/info 를 보낸 유저들에게만 보내지는 것으로
+   * 수정되면서 아래 테스트가 무의미해졌고, 해당 기능은 UserModule 테스트에서 충분히 커버된다고 생각하여
+   * skip 처리
+   */
+  describe.skip('userActivity (WS)', () => {
     let clientSockets: Socket[];
     beforeEach(async () => {
       clientSockets = [
@@ -109,9 +113,7 @@ describe('UserStatusModule (e2e)', () => {
       });
     });
 
-    afterEach(async () => {
-      clientSockets.forEach((socket) => socket.close());
-    });
+    afterEach(async () => clientSockets.forEach((socket) => socket.close()));
 
     it('should emit userActivity when a user is connected', async () => {
       const [userActivityOne, userActivityTwo] = await Promise.all([


### PR DESCRIPTION
## 개요
- #165  완료.
- 유저가 `GET /user/:userId/info` 요청을 friendToggleList 에서 보내는지 여부에 대한 확인이 필요하여 [`friendListOpened`](https://www.notion.so/WebSocket-API-v2-a2be4fca0aad467c83f83005c6a8352d?pvs=4#209d5a0ea15649489a9da2efa4d792fc) & [`friendListClosed`](https://www.notion.so/WebSocket-API-v2-a2be4fca0aad467c83f83005c6a8352d?pvs=4#1d2c9e4799da4c80aaddd70d8144565d) 이벤트를 만들었습니다.
  - 클라이언트는 friendToggleList 가 열릴 때 `friendListOpened` 이벤트를, 닫힐 때 `friendListClosed` 이벤트를 보내주시면 됩니다.
  - 이외에 클라이언트 쪽에서 바뀌어야하는 부분은 없을 것 같습니다.
  - 드디어 진정한 스토킹 서비스로 거듭났습...아악...!!

## 작업 사항
- ActivityManager 에서 특정 UI & friendList 에서 보여지고 있는 유저마다 보고 있는 유저들 저장.
- ActivityManager 에서 friendToggleList 를 열어두고 있는 유저들 저장.
- 위 정보 기반으로 소켓 room 관리하여 특정 유저의 activity 가 변경되었을 때, 해당 유저의 유저 컴포넌트를 보고 있는 유저들에게만 `userActivity` 이벤트가 발송되게 구현.

close #165
