### PR TITLE
✨ feat : 게임 데이터 흐름 추가 DRAFT

### DIFF
--- a/backend/src/game/interceptor/ladder-queue.interceptor.ts
+++ b/backend/src/game/interceptor/ladder-queue.interceptor.ts
@@ -59,8 +59,8 @@ export class LadderQueueInterceptor implements NestInterceptor {
       this.gameService
         .createLadderGame(this.matchedPair as [UserId, UserId])
         .finally(() => {
-          this.matchedPair.length = 0;
           this.matchedPair.forEach((id) => this.usersInQueue.delete(id));
+          this.matchedPair.length = 0;
         });
     }
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,11 +4,14 @@ import { RecoilRoot } from 'recoil';
 import Header from './components/common/Header';
 import Main from './components/common/Main';
 import Navigation from './components/common/Navigation';
+import UserIdInput from './UserIdInput.test';
 import './style/App.css';
 
 function App() {
   return (
     <RecoilRoot>
+      {import.meta.env.DEV === true &&
+        sessionStorage.getItem('x-user-id') === null && <UserIdInput />}
       <BrowserRouter>
         <Header />
         <Navigation />

--- a/frontend/src/UserIdInput.test.tsx
+++ b/frontend/src/UserIdInput.test.tsx
@@ -1,0 +1,34 @@
+import { useRef, useState } from 'react';
+import instance from './util/Axios';
+
+export default function UserIdInput() {
+  const [isSet, setIsSet] = useState(
+    sessionStorage.getItem('x-user-id') !== null,
+  );
+  const inputRef = useRef(null);
+
+  return (
+    <>
+      {!isSet && (
+        <div className="userIdModal">
+          <input ref={inputRef} className="userIdInput" placeholder="User ID" />
+          <button
+            className="userIdButton"
+            type="button"
+            onClick={() => {
+              if (inputRef.current === null) return;
+              const userId = (inputRef.current as HTMLInputElement).value;
+              if (userId.length === 5 && !isNaN(Number(userId))) {
+                sessionStorage.setItem('x-user-id', userId);
+                setIsSet(true);
+                instance.defaults.headers.common['x-user-id'] = userId;
+              }
+            }}
+          >
+            SUBMIT
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/GameRoom/GameMenu.tsx
+++ b/frontend/src/components/GameRoom/GameMenu.tsx
@@ -1,10 +1,24 @@
-export default function GameMenu({ isOwner }: GameMenuProps) {
+export default function GameMenu({
+  isRank,
+  isOwner,
+  startGame,
+}: GameMenuProps) {
+  const handleStartClick = () => startGame();
+
+  const handleMapClick = () => {};
+
   return (
     <div className="gameMenu">
-      <button className="gameButton gameStartButton" type="button">
-        START GAME
-      </button>
-      {isOwner && (
+      {!isRank && (
+        <button
+          className="gameButton gameStartButton"
+          type="button"
+          onClick={handleStartClick}
+        >
+          START GAME
+        </button>
+      )}
+      {!isRank && isOwner && (
         <button className="gameButton gameMapButton" type="button">
           MAPS
         </button>
@@ -16,5 +30,7 @@ export default function GameMenu({ isOwner }: GameMenuProps) {
 // SECTION : Interfaces
 
 interface GameMenuProps {
+  isRank: boolean;
   isOwner: boolean;
+  startGame: () => void;
 }

--- a/frontend/src/components/GameRoom/GamePlay.tsx
+++ b/frontend/src/components/GameRoom/GamePlay.tsx
@@ -2,7 +2,7 @@ import { useRef } from 'react';
 import { useCanvasResize } from './hooks/GameResizeHooks';
 import { useGamePlay } from './hooks/GamePlayHooks';
 
-export default function GamePlay({ isLeft }: GamePlayProps) {
+export default function GamePlay({ isLeft, isStarted }: GamePlayProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { width, height } = useCanvasResize(parentRef);
@@ -10,7 +10,9 @@ export default function GamePlay({ isLeft }: GamePlayProps) {
 
   return (
     <div className="gamePlay" ref={parentRef}>
-      <canvas id="gameBoard" width={width} height={height} ref={canvasRef} />
+      {isStarted && (
+        <canvas id="gameBoard" width={width} height={height} ref={canvasRef} />
+      )}
     </div>
   );
 }
@@ -19,4 +21,5 @@ export default function GamePlay({ isLeft }: GamePlayProps) {
 
 interface GamePlayProps {
   isLeft: boolean;
+  isStarted: boolean;
 }

--- a/frontend/src/components/GameRoom/hooks/GameDataHooks.tsx
+++ b/frontend/src/components/GameRoom/hooks/GameDataHooks.tsx
@@ -1,0 +1,99 @@
+import { ErrorAlert } from '../../../util/Alert';
+import instance from '../../../util/Axios';
+import { listenEvent, socket } from '../../../util/Socket';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+export function useListenGameEvents(isConnected: boolean) {
+  const nav = useNavigate();
+
+  useEffect(() => {
+    if (isConnected) {
+      listenEvent('gameAborted').then(() => {
+        ErrorAlert(
+          '게임 중단',
+          '상대방이 게임을 중단했습니다.<br/>당신의 승리로 기록되었습니다!',
+        );
+        nav('/waiting-room'); // NOTE : 일반 게임일 때도?
+      });
+      listenEvent('gameCancelled').then(() => {
+        ErrorAlert(
+          '게임 취소',
+          '상대방이 게임에 접속하지 않아 취소되었습니다.',
+        );
+        nav('/waiting-room'); // NOTE : 일반 게임일 때도?
+      });
+    }
+    return () => {
+      socket.off('gameAborted');
+      socket.off('gameCancelled');
+    };
+  }, []);
+}
+
+export function useRequestGame(
+  isConnected: boolean,
+  gameId: string,
+  setIsStarted: React.Dispatch<React.SetStateAction<boolean>>,
+) {
+  const [gameInfo, setGameInfo] = useState<GameInfoData | null>(null);
+  const [players, setPlayers] = useState<[string, string] | null>(null);
+  const nav = useNavigate();
+  const location = useLocation();
+
+  const requestGameStart = async () => {
+    let isRank = false;
+    try {
+      const { data }: { data: GameInfoData } = await instance.get(
+        `/game/${gameId}`,
+      );
+      isRank = data.isRank;
+      setGameInfo(data);
+      setPlayers(
+        data.isLeft
+          ? [data.playerNickname, data.opponentNickname]
+          : [data.opponentNickname, data.playerNickname],
+      );
+    } catch (e) {
+      ErrorAlert('게임 정보 요청', '게임 정보를 가져오는데 실패했습니다.');
+      nav('/waiting-room');
+    }
+    try {
+      await instance.patch(`/game/${gameId}/start`);
+      isRank && setIsStarted(true);
+    } catch (e) {
+      ErrorAlert('게임 시작', '게임을 시작하는데 실패했습니다.');
+      nav('/waiting-room');
+    }
+  };
+
+  const requestSpectate = async () => {
+    try {
+      const { data } = await instance.get(`/game/list/${gameId}`);
+      setGameInfo(data);
+      setPlayers([data.leftPlayer, data.rightPlayer]);
+      data.isRank && setIsStarted(true);
+    } catch (e) {
+      ErrorAlert('관전 요청', '관전 요청이 실패했습니다.');
+      nav('/waiting-room');
+    }
+  };
+
+  useEffect(() => {
+    isConnected && location?.state?.isSpectator
+      ? requestSpectate()
+      : requestGameStart();
+  }, []);
+  return { gameInfo, players };
+}
+
+// SECTION : Interfaces
+
+interface GameInfoData {
+  isRank: boolean;
+  isLeft: boolean;
+  playerId?: number;
+  playerNickname: string;
+  opponentId?: number;
+  opponentNickname: string;
+}

--- a/frontend/src/components/User.tsx
+++ b/frontend/src/components/User.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { myIdState } from '../util/Recoils';
 import { Link } from 'react-router-dom';
-import socket from '../util/Socket';
+import { socket } from '../util/Socket';
 interface Props {
   userId: number;
 }

--- a/frontend/src/components/UserBase.tsx
+++ b/frontend/src/components/UserBase.tsx
@@ -1,6 +1,6 @@
 import instance from '../util/Axios';
 import { ReactNode, useEffect, useState } from 'react';
-import socket from '../util/Socket';
+import { socket } from '../util/Socket';
 import { Link } from 'react-router-dom';
 
 interface Props {

--- a/frontend/src/components/WaitingRoom/GameInProgressButton.tsx
+++ b/frontend/src/components/WaitingRoom/GameInProgressButton.tsx
@@ -1,11 +1,13 @@
 import { MouseEvent, useState } from 'react';
 import { HoverBox } from '../common/HoverBox';
+import { useNavigate } from 'react-router-dom';
 
 export default function GameInProgressButton({
   gameId,
   leftNickname,
   rightNickname,
 }: GameInProgressButtonProps) {
+  const nav = useNavigate();
   const [isHovered, setIsHovered] = useState(false);
   const [hoverInfoCoords, setHoverInfoCoords] = useState<{
     x: number;
@@ -22,6 +24,9 @@ export default function GameInProgressButton({
   const handleMouseMove = (e: MouseEvent) =>
     setHoverInfoCoords({ x: e.clientX + 8, y: e.clientY + 20 });
 
+  const handleClick = () =>
+    nav(`/game/${gameId}`, { state: { isSpectator: true } });
+
   return (
     <>
       <button
@@ -29,6 +34,7 @@ export default function GameInProgressButton({
         onMouseEnter={handleMouseEnter}
         onMouseMove={handleMouseMove}
         onMouseLeave={handleMouseLeave}
+        onClick={handleClick}
       >
         <div>{leftNickname}</div>
         {isHovered ? (

--- a/frontend/src/components/WaitingRoom/GameInProgressButton.tsx
+++ b/frontend/src/components/WaitingRoom/GameInProgressButton.tsx
@@ -2,6 +2,7 @@ import { MouseEvent, useState } from 'react';
 import { HoverBox } from '../common/HoverBox';
 
 export default function GameInProgressButton({
+  gameId,
   leftNickname,
   rightNickname,
 }: GameInProgressButtonProps) {
@@ -51,6 +52,7 @@ export default function GameInProgressButton({
 // SECTION: Interfaces
 
 interface GameInProgressButtonProps {
+  gameId: string;
   leftNickname: string;
   rightNickname: string;
 }

--- a/frontend/src/components/WaitingRoom/GameQueueButton.tsx
+++ b/frontend/src/components/WaitingRoom/GameQueueButton.tsx
@@ -1,7 +1,65 @@
+import { useState } from 'react';
+import instance from '../../util/Axios';
+import { listenEvent, socket } from '../../util/Socket';
+import { useNavigate } from 'react-router-dom';
+
 export default function GameEnterQueueButton() {
+  const nav = useNavigate();
+  const [hasEnteredQueue, setHasEnteredQueue] = useState(false);
+
+  const handleButtonClick = () => {
+    hasEnteredQueue
+      ? instance
+          .delete('/game/queue')
+          .then(() => setHasEnteredQueue(false))
+          .catch(err => {})
+      : instance
+          .post('/game/queue')
+          .then(() => {
+            setHasEnteredQueue(true);
+            listenEvent<NewGameMessage>('newGame').then(({ gameId }) =>
+              nav(`/game/${gameId}`),
+            );
+          })
+          .catch(err => {});
+  };
+
+  const generateWavyText = (text: string) => {
+    return (
+      <>
+        {text.split('').map((char, i) => (
+          <span key={i} style={{ '--i': i.toString() } as React.CSSProperties}>
+            {char === ' ' ? '\u00A0' : char}
+          </span>
+        ))}
+      </>
+    );
+  };
+
   return (
-    <button className="gameQueueButton xxxlarge" type="button">
-      GAME START
+    <button
+      className={
+        (hasEnteredQueue ? 'gameQueueButtonClicked' : 'gameQueueButton') +
+        ' xxxlarge'
+      }
+      type="button"
+      onClick={handleButtonClick}
+    >
+      <p>
+        {hasEnteredQueue ? 'Looking for an Opponent' : 'GAME START'}
+        {hasEnteredQueue && generateWavyText('...')}
+      </p>
+      {hasEnteredQueue && (
+        <p className="large">
+          (새로고침을 하거나 버튼을 한번 더 누르면 매칭 요청이 취소됩니다)
+        </p>
+      )}
     </button>
   );
+}
+
+// SECTION : Interfaces
+
+interface NewGameMessage {
+  gameId: string;
 }

--- a/frontend/src/components/WaitingRoom/GamesList.tsx
+++ b/frontend/src/components/WaitingRoom/GamesList.tsx
@@ -16,13 +16,11 @@ export default function GamesList() {
     setGames(games.filter(({ id }) => id !== endedId));
 
   useEffect(() => {
+    socket.on('gameStarted', gameStartedListener);
+    socket.on('gameEnded', gameEndedListener);
     instance
       .get('/game/list')
-      .then(({ data }) => {
-        setGames(data.games);
-        socket.on('gameStarted', gameStartedListener);
-        socket.on('gameEnded', gameEndedListener);
-      })
+      .then(({ data }) => setGames(data.games))
       .catch(() => {
         ErrorAlert(
           '진행 중인 게임 목록',
@@ -30,8 +28,8 @@ export default function GamesList() {
         );
       });
     return () => {
-      socket.off('gameStarted', gameStartedListener);
-      socket.off('gameEnded', gameEndedListener);
+      socket.off('gameStarted');
+      socket.off('gameEnded');
     };
   }, []);
 

--- a/frontend/src/components/WaitingRoom/GamesList.tsx
+++ b/frontend/src/components/WaitingRoom/GamesList.tsx
@@ -1,115 +1,71 @@
-import { useEffect, useState } from 'react';
-import instance from '../../util/Axios';
+import { ErrorAlert } from '../../util/Alert';
 import GameInProgressButton from './GameInProgressButton';
+import instance from '../../util/Axios';
+import { socket } from '../../util/Socket';
+import { useEffect, useState } from 'react';
 
 export default function GamesList() {
   const [games, setGames] = useState<
     { id: string; left: string; right: string }[]
-  >([
-    {
-      id: 'example',
-      left: 'ghan',
-      right: 'yongjule',
-    },
-    {
-      id: 'example',
-      left: 'eunlee',
-      right: 'hankkim',
-    },
-    {
-      id: 'example',
-      left: 'jiskim',
-      right: 'hannkim',
-    },
-    {
-      id: 'example',
-      left: 'nkim',
-      right: 'jiychoi',
-    },
-    {
-      id: 'example',
-      left: 'ghan',
-      right: 'yongjule',
-    },
-    {
-      id: 'example',
-      left: 'eunlee',
-      right: 'hankkim',
-    },
-    {
-      id: 'example',
-      left: 'jiskim',
-      right: 'hannkim',
-    },
-    {
-      id: 'example',
-      left: 'nkim',
-      right: 'jiychoi',
-    },
-    {
-      id: 'example',
-      left: 'ghan',
-      right: 'yongjule',
-    },
-    {
-      id: 'example',
-      left: 'eunlee',
-      right: 'hankkim',
-    },
-    {
-      id: 'example',
-      left: 'jiskim',
-      right: 'hannkim',
-    },
-    {
-      id: 'example',
-      left: 'nkim',
-      right: 'jiychoi',
-    },
-    {
-      id: 'example',
-      left: 'ghan',
-      right: 'yongjule',
-    },
-    {
-      id: 'example',
-      left: 'eunlee',
-      right: 'hankkim',
-    },
-    {
-      id: 'example',
-      left: 'jiskim',
-      right: 'hannkim',
-    },
-    {
-      id: 'example',
-      left: 'nkim',
-      right: 'jiychoi',
-    },
-  ]);
+  >([]);
+
+  const gameStartedListener = ({ id, left, right }: GameStartedMessage) =>
+    setGames([{ id, left, right }, ...games]);
+
+  const gameEndedListener = ({ id: endedId }: GameEndedMessage) =>
+    setGames(games.filter(({ id }) => id !== endedId));
+
   useEffect(() => {
-    // instance
-    //   .get('/game/list')
-    //   .then(({ data }) => {
-    //     setGames(data.games);
-    //   })
-    //   .catch(err => {
-    //     /* do somethin */
-    //   });
+    instance
+      .get('/game/list')
+      .then(({ data }) => {
+        setGames(data.games);
+        socket.on('gameStarted', gameStartedListener);
+        socket.on('gameEnded', gameEndedListener);
+      })
+      .catch(() => {
+        ErrorAlert(
+          '진행 중인 게임 목록',
+          '진행 중인 게임 목록을 불러오는데 실패했습니다<br/>다시 시도해주세요',
+        );
+      });
+    return () => {
+      socket.off('gameStarted', gameStartedListener);
+      socket.off('gameEnded', gameEndedListener);
+    };
   }, []);
 
   return (
     <div className="gamesList">
-      {games?.map(game => {
-        return (
-          <div className="gameWrapper">
-            <GameInProgressButton
-              leftNickname={game.left}
-              rightNickname={game.right}
-            />
-          </div>
-        );
-      })}
+      {games.length ? (
+        games.map(({ id, left, right }) => {
+          return (
+            <div key={id} className="gameWrapper">
+              <GameInProgressButton
+                gameId={id}
+                leftNickname={left}
+                rightNickname={right}
+              />
+            </div>
+          );
+        })
+      ) : (
+        <div className="noGamesInProgress xlarge">
+          진행 중인 게임이 없습니다
+        </div>
+      )}
     </div>
   );
+}
+
+// SECTION : Interfaces
+
+interface GameStartedMessage {
+  id: string;
+  left: string;
+  right: string;
+}
+
+interface GameEndedMessage {
+  id: string;
 }

--- a/frontend/src/components/common/FriendsList.tsx
+++ b/frontend/src/components/common/FriendsList.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import instance from '../../util/Axios';
 import User from '../User';
-import socket from '../../util/Socket';
+import { socket } from '../../util/Socket';
 // 친구 요청 component
 
 function FriendsList() {

--- a/frontend/src/components/hooks/EmitCurrentUi.tsx
+++ b/frontend/src/components/hooks/EmitCurrentUi.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { listenEvent, socket } from '../../util/Socket';
+
+export function useCurrentUi(
+  isConnected: boolean,
+  setIsConnected: React.Dispatch<React.SetStateAction<boolean>>,
+  ui: CurrentUi,
+) {
+  useEffect(() => {
+    isConnected
+      ? socket.emit('currentUi', { ui })
+      : listenEvent('connect').then(() => {
+          socket.emit('currentUi', { ui });
+          setIsConnected(true);
+        });
+    return () => {
+      socket.off('connect');
+    };
+  }, []);
+}
+
+type CurrentUi =
+  | 'chats'
+  | `chatRooms-${number}`
+  | `game-${string}`
+  | 'profile'
+  | 'ranks'
+  | 'watchingGame'
+  | 'waitingRoom';

--- a/frontend/src/style/App.css
+++ b/frontend/src/style/App.css
@@ -28,3 +28,35 @@ main {
   display: grid;
   justify-items: center;
 }
+
+/* TEST ONLY */
+
+.userIdModal {
+  align-items: center;
+  border-radius: 0.5rem;
+  background-color: var(--primary);
+  display: flex;
+  height: 10%;
+  justify-content: space-around;
+  left: 50%;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 240px;
+  z-index: 12;
+  padding: 0 2rem;
+}
+
+.userIdInput {
+  border: 0;
+  border-radius: 0.5rem;
+  height: 2rem;
+  margin: 0;
+  padding: 0 0.3rem;
+}
+
+.userIdButton {
+  background-color: var(--secondary);
+  border-radius: 0.5rem;
+  height: 2rem;
+}

--- a/frontend/src/style/WaitingRoom.css
+++ b/frontend/src/style/WaitingRoom.css
@@ -16,7 +16,6 @@
   border-radius: 1rem;
   box-shadow: 0.5rem 0.5rem var(--primary);
   color: var(--primary);
-  font-family: 'DungGeunMo';
   height: 80%;
   place-self: center;
   transition: 0.5s;
@@ -27,6 +26,43 @@
   background-color: var(--primary);
   box-shadow: 0.5rem 0.5rem var(--secondary);
   color: var(--secondary);
+}
+
+.gameQueueButtonClicked {
+  background-color: var(--primary);
+  border-radius: 1rem;
+  box-shadow: 0.5rem 0.5rem var(--secondary);
+  color: var(--secondary);
+  height: 80%;
+  place-self: center;
+  transition: 0.5s;
+  width: 84%;
+}
+
+.gameQueueButtonClicked p {
+  margin-bottom: 0.5rem;
+}
+
+.gameQueueButtonClicked span {
+  display: inline-block;
+  animation: wave 1.5s infinite ease-in-out;
+  animation-delay: calc(0.25s * var(--i));
+}
+
+@keyframes wave {
+  0%,
+  40%,
+  100% {
+    transform: translateY(0);
+  }
+  20% {
+    transform: translateY(-1rem);
+  }
+}
+
+.gameQueueButtonText {
+  animation: wave 1.5s infinite ease-in-out;
+  animation-delay: 0.5s;
 }
 
 /* SECTION : GamesList */
@@ -55,6 +91,11 @@
   display: grid;
   min-height: 25%;
   width: 100%;
+}
+
+.noGamesInProgress {
+  color: var(--secondary_dark);
+  margin: 10% 0;
 }
 
 /* SECTION : GamesInProgressButton */

--- a/frontend/src/util/Alert.ts
+++ b/frontend/src/util/Alert.ts
@@ -1,6 +1,6 @@
 import Swal from 'sweetalert2';
 import withReactContent from 'sweetalert2-react-content';
-import '../style/presets/Alert.css'
+import '../style/presets/Alert.css';
 
 export const ReactSwal = withReactContent(Swal).mixin({
   customClass: {
@@ -16,15 +16,15 @@ export const SuccessAlert = (title: string, text: string) => {
     title,
     text,
   });
-}
+};
 
 export const ErrorAlert = (title: string, text: string) => {
   return ReactSwal.fire({
     icon: 'error',
     title,
-    text,
+    html: `<p>${text}</p>`,
   });
-}
+};
 
 export const ConfirmAlert = (title: string, text: string) => {
   return ReactSwal.fire({
@@ -35,4 +35,4 @@ export const ConfirmAlert = (title: string, text: string) => {
     confirmButtonText: '확인',
     cancelButtonText: '취소',
   });
-}
+};

--- a/frontend/src/util/Axios.ts
+++ b/frontend/src/util/Axios.ts
@@ -5,6 +5,7 @@ const instance = axios.create({
 });
 
 // FIXME : x-user-id 보내기
-instance.defaults.headers.common['x-user-id'] = import.meta.env.VITE_X_USER_ID;
+instance.defaults.headers.common['x-user-id'] =
+  sessionStorage.getItem('x-user-id') ?? import.meta.env.VITE_X_USER_ID;
 
 export default instance;

--- a/frontend/src/util/Socket.ts
+++ b/frontend/src/util/Socket.ts
@@ -2,7 +2,8 @@ import io from 'socket.io-client';
 
 export const socket = io('http://localhost:3000', {
   extraHeaders: {
-    'x-user-id': import.meta.env.VITE_X_USER_ID,
+    'x-user-id':
+      sessionStorage.getItem('x-user-id') ?? import.meta.env.VITE_X_USER_ID,
   },
   withCredentials: true,
 });

--- a/frontend/src/util/Socket.ts
+++ b/frontend/src/util/Socket.ts
@@ -1,15 +1,11 @@
 import io from 'socket.io-client';
 
-const socket = io('http://localhost:3000', {
+export const socket = io('http://localhost:3000', {
   extraHeaders: {
     'x-user-id': import.meta.env.VITE_X_USER_ID,
   },
   withCredentials: true,
 });
 
-export const initSocketConnection = () => {
-  if (socket.connected) return socket;
-  socket.connect();
-};
-
-export default socket;
+export const listenEvent = <T>(event: string) =>
+  new Promise<T>(resolve => socket.on(event, resolve));

--- a/frontend/src/views/Chats.tsx
+++ b/frontend/src/views/Chats.tsx
@@ -3,7 +3,7 @@ import { Channels } from '../components/chats/interface';
 import ChatsFrame from '../components/chats/ChatsFrame';
 import ChatsBody from '../components/chats/ChatsBody';
 import instance from '../util/Axios';
-import socket from '../util/Socket';
+import { socket } from '../util/Socket';
 import '../style/Chats.css';
 
 function Chats() {

--- a/frontend/src/views/Ranks.tsx
+++ b/frontend/src/views/Ranks.tsx
@@ -1,6 +1,6 @@
 import MyRank from '../components/MyRank';
 import RankList from '../components/RankList';
-import socket from '../util/Socket';
+import { socket } from '../util/Socket';
 import { useEffect } from 'react';
 
 function Ranks() {

--- a/frontend/src/views/WaitingRoom.tsx
+++ b/frontend/src/views/WaitingRoom.tsx
@@ -1,12 +1,23 @@
+import { useState } from 'react';
 import GameQueueButton from '../components/WaitingRoom/GameQueueButton';
 import GamesList from '../components/WaitingRoom/GamesList';
+import { socket } from '../util/Socket';
 import '../style/WaitingRoom.css';
+import { useCurrentUi } from '../components/hooks/EmitCurrentUi';
 
 export default function WaitingRoom() {
+  const [isConnected, setIsConnected] = useState(socket.connected);
+
+  useCurrentUi(isConnected, setIsConnected, 'waitingRoom');
+
   return (
     <div className="waitingRoom">
-      <GameQueueButton />
-      <GamesList />
+      {isConnected && (
+        <>
+          <GameQueueButton />
+          <GamesList />
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 개요
- #187 진행 중입니다.
- #197 진행 중입니다.
- #198 완료. 
- #199 완료.

## 작업 사항
- socket connection 확인 후, 'currentUi' 발송하는 `useCurrentUi` hook 구현.
- 대기큐 접속, 대기 취소 구현.
- 매칭되면 게임방으로 이동 및 게임방에서 게임 정보 요청.
- 새게임 시작되거나, 게임 끝났을 때 진행 중인 게임 목록에 반영.
- 게임 시작 큐에서 매칭된 후 timeout 발생하던 문제 fix.
- input box 로 임시 유저 id 설정, sessionStorage 로 관리.
  - 탭마다 다른 유저로 사용 가능합니다.
- gameStarted, gameEnded 이벤트 적용.
- 게임 관전 UI 이동.
- 게임방에서 게임 시작, 관전, gameAborted, gameCancelled 이벤트 적용.

## 변경점
- socket event on 하는 promise wrapper 를 만들면서 `export default socket` 을 `export socket` 로 수정했습니다.

## 스크린샷
- 게임 대기큐 접속, 대기 취소 UI.

https://user-images.githubusercontent.com/83805691/222435490-8b4fd86f-d6f9-451c-bd58-06a169aeef09.mov

