### PR TITLE
✨  feat : chats Axios 에러 핸들링 및 style 적용

### DIFF
--- a/frontend/src/components/chats/Channel.tsx
+++ b/frontend/src/components/chats/Channel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
+import { ErrorAlert } from '../../util/Alert';
 import instance from '../../util/Axios';
 import { myIdState } from '../../util/Recoils';
 import FormModal from './FormModal';
@@ -19,7 +20,6 @@ function Channel({ channel, isJoined }: ChannelProps) {
   const { channelId, channelName, isDm, memberCount, accessMode, unseenCount } =
     channel;
   const nav = useNavigate();
-
   const icon =
     accessMode === 'public' ? '🌎' : accessMode === 'protected' ? '🔐' : '🚧';
 
@@ -33,7 +33,7 @@ function Channel({ channel, isJoined }: ChannelProps) {
       instance
         .put(`/chats/${channelId}/user/${myId}`)
         .then(() => nav(`/chats/${channelId}`))
-        .catch(err => alert(`히히 못들어가! ${err.response.status}`));
+        .catch(() => ErrorAlert('채널 입장 실패', '오류가 발생했습니다.'));
   };
 
   return (

--- a/frontend/src/components/chats/ChannelCreate.tsx
+++ b/frontend/src/components/chats/ChannelCreate.tsx
@@ -16,7 +16,7 @@ function ChannelCreate() {
       {showModal &&
         createPortal(
           <FormModal
-            title={'방을 만들어 보아요~'}
+            title={'채팅방 생성'}
             form={<ChannelCreateForm hidden={() => setShowModal(false)} />}
             hidden={() => setShowModal(false)}
           />,

--- a/frontend/src/components/chats/ChannelCreate.tsx
+++ b/frontend/src/components/chats/ChannelCreate.tsx
@@ -10,8 +10,8 @@ function ChannelCreate() {
 
   return (
     <>
-      <button className="chatsNewButton" onClick={() => setShowModal(true)}>
-        Create!
+      <button className="chatsNewButton xxlarge textBold" onClick={() => setShowModal(true)}>
+        +
       </button>
       {showModal &&
         createPortal(

--- a/frontend/src/components/chats/ChannelCreateForm.tsx
+++ b/frontend/src/components/chats/ChannelCreateForm.tsx
@@ -1,70 +1,69 @@
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import instance from '../../util/Axios';
-import { ErrorAlert, SuccessAlert } from '../../util/Alert';
+import { ConfirmAlert, ErrorAlert, SuccessAlert } from '../../util/Alert';
 
-const NAME_ERR = '채널 이름은 1~128자로 입력해주세요';
-const PASSWORD_ERR = '비밀번호는 8~16자로 입력해주세요';
-type InputErrorInfo = 'name' | 'password' | 'none';
+const NAME_ERR = '채널은 1~128자로 입력해주세요';
+const PWD_ERR = '비밀번호는 8~16자로 입력해주세요';
+const PWD_REGEX = /^[a-zA-Z0-9]{8,16}$/;
+
+interface InputErrorInfo {
+  name: boolean;
+  password: boolean;
+}
 
 interface ChannelCreateFormProps {
   hidden: () => void;
 }
 
-
-
-const isAlphanumeric = (str: string) => {
-  const reg = /^[a-zA-Z0-9]*$/;
-  return reg.test(str);
-};
-
 function ChannelCreateForm({ hidden }: ChannelCreateFormProps) {
   const [channelName, setChannelName] = useState<string>('');
   const [accessMode, setAccessMode] = useState<string>('public');
   const [password, setPassword] = useState<string | undefined>(undefined);
-  const [error, setError] = useState<InputErrorInfo>('name');
+  const [error, setError] = useState<InputErrorInfo>({
+    name: false,
+    password: false,
+  });
   const elemRef = useRef<HTMLFormElement>(null);
   const nav = useNavigate();
+  
+  ConfirmAlert('채널 생성', '채널을 생성하시겠습니까?');
 
   const handleName = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
-    if (value.length > 0 && value.length < 129) {
-      setChannelName(value);
-      setError('none');
-    } else {
-      setError('name');
-    }
+    setChannelName(value);
+    value.length > 0 && value.length < 129
+      ? setError({ ...error, name: false })
+      : setError({ ...error, name: true });
   };
 
   const handlePassword = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
-    if (value.length > 7 && value.length < 17) {
-      setPassword(value);
-    } else {
-      setError('password');
-    }
+    setPassword(value);
+    PWD_REGEX.test(value)
+      ? setError({ ...error, password: false })
+      : setError({ ...error, password: true });
   };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    error === 'none'
-      ? instance
+    error.name || error.password
+      ? ErrorAlert('채널 생성 실패', '입력값을 확인해주세요.')
+      : instance
           .post('/chats', {
             channelName,
             accessMode,
             password,
           })
           .then(res => {
-            SuccessAlert('채널 생성 성공', '채널로 이동합니다').then(() => {
+            SuccessAlert('채널 생성 성공', '채널로 이동합니다.').then(() => {
               hidden();
               nav(res.headers.location);
             });
           })
           .catch(err => {
-            console.log(err);
-            ErrorAlert('채널 생성 실패', err.message); //FIXME : 에러 메시지 변경
-          })
-      : ErrorAlert('채널 생성 실패', '입력값을 확인해주세요'); // FIXME : 에러 메시지 변경
+            ErrorAlert('채널 생성 실패', '오류가 발생했습니다.'); //FIXME : 에러 메시지 변경
+          });
   };
 
   return (
@@ -76,55 +75,66 @@ function ChannelCreateForm({ hidden }: ChannelCreateFormProps) {
         ref={elemRef}
       >
         <label className="formModalField" htmlFor="channelName">
-          채널 이름
-          <input
-            type="text"
-            name="channelName"
-            onChange={handleName}
-            autoFocus={true}
-            autoComplete="off"
-            onKeyDown={e => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                elemRef.current?.children[1].querySelector('select')?.focus();
-              }
-            }}
-          />
-          {error === 'name' && <span className="xxsmall">{NAME_ERR}</span>}
+          <div className="formModalFieldName"> 채널 이름</div>
+          <div className="formModalFieldValue">
+            <input
+              className="formModalFieldInput"
+              type="text"
+              name="channelName"
+              autoFocus={true}
+              autoComplete="off"
+              value={channelName}
+              onChange={handleName}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  elemRef.current?.children[1].querySelector('select')?.focus();
+                }
+              }}
+            />
+            {error.name && (
+              <span className="formModalFieldError xsmall">{NAME_ERR}</span>
+            )}
+          </div>
         </label>
         <label className="formModalField" htmlFor="accessMode">
-          공개 범위
-          <select
-            name="accessMode"
-            onChange={e => setAccessMode(e.target.value)}
-          >
-            <option value="public">공개</option>
-            <option value="protected">공개 (비밀번호)</option>
-            <option value="private">비공개</option>
-          </select>
+          <div className="formModalFieldName">공개 범위</div>
+          <div className="formModalFieldValue">
+            <select
+              className="formModalFieldInput"
+              name="accessMode"
+              onChange={e => setAccessMode(e.target.value)}
+            >
+              <option value="public">공개</option>
+              <option value="protected">공개 (비밀번호)</option>
+              <option value="private">비공개</option>
+            </select>
+          </div>
         </label>
         {accessMode === 'protected' && (
-          <>
-            <label className="formModalField" htmlFor="password">
-              비밀번호
+          <label className="formModalField" htmlFor="password">
+            <div className="formModalFieldName">비밀번호</div>
+            <div className="formModalFieldValue">
               <input
+                className="formModalFieldInput"
                 type="password"
                 name="password"
-                onChange={handlePassword}
                 autoFocus={true}
+                value={password}
+                onChange={handlePassword}
               />
-              {error === 'password' && (
-                <span className="xxsmall">{PASSWORD_ERR}</span>
+              {error.password && (
+                <span className="formModalFieldError xsmall"> {PWD_ERR} </span>
               )}
-            </label>
-          </>
+            </div>
+          </label>
         )}
       </form>
       <div className="formModalButtons">
-        <button type="submit" form="createChat">
+        <button className='formModalConfirm regular' type="submit" form="createChat">
           확인
         </button>
-        <button onClick={hidden}>취소</button>
+        <button className='formModalCancel regular' onClick={hidden}>취소</button>
       </div>
     </>
   );

--- a/frontend/src/components/chats/ChannelCreateForm.tsx
+++ b/frontend/src/components/chats/ChannelCreateForm.tsx
@@ -26,8 +26,6 @@ function ChannelCreateForm({ hidden }: ChannelCreateFormProps) {
   });
   const elemRef = useRef<HTMLFormElement>(null);
   const nav = useNavigate();
-  
-  ConfirmAlert('채널 생성', '채널을 생성하시겠습니까?');
 
   const handleName = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
@@ -75,7 +73,7 @@ function ChannelCreateForm({ hidden }: ChannelCreateFormProps) {
         ref={elemRef}
       >
         <label className="formModalField" htmlFor="channelName">
-          <div className="formModalFieldName"> 채널 이름</div>
+          <p className="formModalFieldName"> 채널 이름</p>
           <div className="formModalFieldValue">
             <input
               className="formModalFieldInput"
@@ -98,7 +96,7 @@ function ChannelCreateForm({ hidden }: ChannelCreateFormProps) {
           </div>
         </label>
         <label className="formModalField" htmlFor="accessMode">
-          <div className="formModalFieldName">공개 범위</div>
+          <p className="formModalFieldName">공개 범위</p>
           <div className="formModalFieldValue">
             <select
               className="formModalFieldInput"
@@ -113,7 +111,7 @@ function ChannelCreateForm({ hidden }: ChannelCreateFormProps) {
         </label>
         {accessMode === 'protected' && (
           <label className="formModalField" htmlFor="password">
-            <div className="formModalFieldName">비밀번호</div>
+            <p className="formModalFieldName">비밀번호</p>
             <div className="formModalFieldValue">
               <input
                 className="formModalFieldInput"

--- a/frontend/src/components/chats/ChannelSvg.tsx
+++ b/frontend/src/components/chats/ChannelSvg.tsx
@@ -1,0 +1,133 @@
+interface SvgProps {
+  width?: string; // SVG width
+  height?: string; // SVG height
+  fill?: string; // SVG Fill color (background)
+  stroke?: string; // SVG Stroke color (line)
+  strokeWidth?: number; // SVG Stroke width (line width)
+}
+import '../../style/Chats.css';
+
+export function UsersIcon({ width, height, stroke, strokeWidth }: SvgProps) {
+  return (
+    <svg
+      className="channelSvgIcon"
+      width={width || '1rem'}
+      height={height || '1rem'}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M16 3.46776C17.4817 4.20411 18.5 5.73314 18.5 7.5C18.5 9.26686 17.4817 10.7959 16 11.5322M18 16.7664C19.5115 17.4503 20.8725 18.565 22 20M2 20C3.94649 17.5226 6.58918 16 9.5 16C12.4108 16 15.0535 17.5226 17 20M14 7.5C14 9.98528 11.9853 12 9.5 12C7.01472 12 5 9.98528 5 7.5C5 5.01472 7.01472 3 9.5 3C11.9853 3 14 5.01472 14 7.5Z"
+        stroke={stroke || '#3d4f73'}
+        strokeWidth={strokeWidth || 2.2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function DmChannelIcon({
+  width,
+  height,
+  stroke,
+  strokeWidth,
+}: SvgProps) {
+  return (
+    <svg
+      className="channelSvgIcon"
+      width={width || '1rem'}
+      height={height || '1rem'}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M20 4L3 9.31372L10.5 13.5M20 4L14.5 21L10.5 13.5M20 4L10.5 13.5"
+        stroke={stroke || '#3d4f73'}
+        strokeWidth={strokeWidth || 2.2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function MsgNotificationIcon({
+  width,
+  height,
+  stroke,
+  strokeWidth,
+}: SvgProps) {
+  return (
+    <svg
+      className="channelSvgIcon"
+      width={width || '1rem'}
+      height={height || '1rem'}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.0002 19C15.0002 20.6569 13.6571 22 12.0002 22C10.3434 22 9.00025 20.6569 9.00025 19M13.7968 6.23856C14.2322 5.78864 14.5002 5.17562 14.5002 4.5C14.5002 3.11929 13.381 2 12.0002 2C10.6195 2 9.50025 3.11929 9.50025 4.5C9.50025 5.17562 9.76825 5.78864 10.2037 6.23856M2.54707 8.32296C2.53272 6.87161 3.3152 5.51631 4.57928 4.80306M21.4534 8.32296C21.4678 6.87161 20.6853 5.51631 19.4212 4.80306M18.0002 11.2C18.0002 9.82087 17.3681 8.49823 16.2429 7.52304C15.1177 6.54786 13.5915 6 12.0002 6C10.4089 6 8.88283 6.54786 7.75761 7.52304C6.63239 8.49823 6.00025 9.82087 6.00025 11.2C6.00025 13.4818 5.43438 15.1506 4.72831 16.3447C3.92359 17.7056 3.52122 18.3861 3.53711 18.5486C3.55529 18.7346 3.58876 18.7933 3.73959 18.9036C3.87142 19 4.53376 19 5.85844 19H18.1421C19.4667 19 20.1291 19 20.2609 18.9036C20.4117 18.7933 20.4452 18.7346 20.4634 18.5486C20.4793 18.3861 20.0769 17.7056 19.2722 16.3447C18.5661 15.1506 18.0002 13.4818 18.0002 11.2Z"
+        stroke={stroke || '#3d4f73'}
+        strokeWidth={strokeWidth || 2.2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function ProtectedChannelIcon({
+  width,
+  height,
+  stroke,
+  strokeWidth,
+}: SvgProps) {
+  return (
+    <svg
+      className="channelSvgIcon"
+      width={width || '1rem'}
+      height={height || '1rem'}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M17 10V8C17 5.23858 14.7614 3 12 3C9.23858 3 7 5.23858 7 8V10M12 14.5V16.5M8.8 21H15.2C16.8802 21 17.7202 21 18.362 20.673C18.9265 20.3854 19.3854 19.9265 19.673 19.362C20 18.7202 20 17.8802 20 16.2V14.8C20 13.1198 20 12.2798 19.673 11.638C19.3854 11.0735 18.9265 10.6146 18.362 10.327C17.7202 10 16.8802 10 15.2 10H8.8C7.11984 10 6.27976 10 5.63803 10.327C5.07354 10.6146 4.6146 11.0735 4.32698 11.638C4 12.2798 4 13.1198 4 14.8V16.2C4 17.8802 4 18.7202 4.32698 19.362C4.6146 19.9265 5.07354 20.3854 5.63803 20.673C6.27976 21 7.11984 21 8.8 21Z"
+        stroke={stroke || '#3d4f73'}
+        strokeWidth={strokeWidth || 2.2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function PrivateChannelIcon({
+  width,
+  height,
+  stroke,
+  strokeWidth,
+}: SvgProps) {
+  return (
+    <svg
+      className="channelSvgIcon"
+      width={width || '1rem'}
+      height={height || '1rem'}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M10.7429 5.09232C11.1494 5.03223 11.5686 5 12.0004 5C17.1054 5 20.4553 9.50484 21.5807 11.2868C21.7169 11.5025 21.785 11.6103 21.8231 11.7767C21.8518 11.9016 21.8517 12.0987 21.8231 12.2236C21.7849 12.3899 21.7164 12.4985 21.5792 12.7156C21.2793 13.1901 20.8222 13.8571 20.2165 14.5805M6.72432 6.71504C4.56225 8.1817 3.09445 10.2194 2.42111 11.2853C2.28428 11.5019 2.21587 11.6102 2.17774 11.7765C2.1491 11.9014 2.14909 12.0984 2.17771 12.2234C2.21583 12.3897 2.28393 12.4975 2.42013 12.7132C3.54554 14.4952 6.89541 19 12.0004 19C14.0588 19 15.8319 18.2676 17.2888 17.2766M3.00042 3L21.0004 21M9.8791 9.87868C9.3362 10.4216 9.00042 11.1716 9.00042 12C9.00042 13.6569 10.3436 15 12.0004 15C12.8288 15 13.5788 14.6642 14.1217 14.1213"
+        stroke={stroke || '#3d4f73'}
+        strokeWidth={strokeWidth || 2.2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/chats/ChatsBody.tsx
+++ b/frontend/src/components/chats/ChatsBody.tsx
@@ -1,21 +1,30 @@
 import { lazy, Suspense } from 'react';
+import ChannelCreate from './ChannelCreate';
 import { ChannelInfo } from './interface';
+
+const Channel = lazy(() => import('./Channel'));
 
 interface ChatsJoinedProps {
   channels: ChannelInfo[];
   isJoined: boolean;
 }
 
-const Channel = lazy(() => import('./Channel'));
 
 function ChatsBody({ channels, isJoined }: ChatsJoinedProps) {
   return (
     <div className="chatsBody">
-      <Suspense fallback={<div>로딩중이란다~ {/* TODO : 적절한 spin */}</div>}>
-        {channels.map(channel => (
-          <Channel key={channel.channelId} channel={channel} isJoined={isJoined} />
-        ))}
+      <Suspense fallback={<div className="chatsListSpin"></div>}>
+        {channels.length > 0
+          ? channels.map(channel => (
+              <Channel
+                key={channel.channelId}
+                channel={channel}
+                isJoined={isJoined}
+              />
+            ))
+          : '채널이 없어요~'}
       </Suspense>
+      {isJoined === false && <ChannelCreate />}
     </div>
   );
 }

--- a/frontend/src/components/chats/ChatsFrame.tsx
+++ b/frontend/src/components/chats/ChatsFrame.tsx
@@ -9,13 +9,12 @@ interface ChatsBaseProps {
 function ChatsFrame({ purpose, children }: ChatsBaseProps) {
   return (
     <div className={`chatsFrame ${purpose}`}>
-      <div className="chatsHeader">
+      <div className="chatsHeader xlarge">
         {purpose === 'chatsJoined' ? (
-          <span>내가 참여한 채널 </span>
+          <h1>참여한 채널 </h1>
         ) : (
           <>
-            <span>전체 채널 </span>
-            <ChannelCreate />
+            <h1>전체 채널 </h1>
           </>
         )}
       </div>

--- a/frontend/src/components/chats/FormModal.tsx
+++ b/frontend/src/components/chats/FormModal.tsx
@@ -1,13 +1,13 @@
 import { ReactNode, useEffect, useRef } from 'react';
 import '../../style/FormModal.css';
 
-interface Props {
+interface FormModalProps {
   title: string;
   form: ReactNode;
   hidden: () => void;
 }
 
-function FormModal({ title, form, hidden }: Props) {
+function FormModal({ title, form, hidden }: FormModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
 
   const handleClickOutside = (e: MouseEvent) => {
@@ -46,7 +46,7 @@ function FormModal({ title, form, hidden }: Props) {
     <div className="formModal">
       <div className="formModalOverlay" ref={overlayRef} />
       <div className="formModalContent">
-        <h2 className="formModalTitle large"> {title}</h2>
+        <h2 className="formModalTitle xlarge"> {title}</h2>
         {form}
       </div>
     </div>

--- a/frontend/src/components/chats/FormModal.tsx
+++ b/frontend/src/components/chats/FormModal.tsx
@@ -9,6 +9,7 @@ interface FormModalProps {
 
 function FormModal({ title, form, hidden }: FormModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
+  
 
   const handleClickOutside = (e: MouseEvent) => {
     if (
@@ -45,7 +46,7 @@ function FormModal({ title, form, hidden }: FormModalProps) {
   return (
     <div className="formModal">
       <div className="formModalOverlay" ref={overlayRef} />
-      <div className="formModalContent">
+      <div className="formModalContent formModalAnimation">
         <h2 className="formModalTitle xlarge"> {title}</h2>
         {form}
       </div>

--- a/frontend/src/components/chats/PasswordForm.tsx
+++ b/frontend/src/components/chats/PasswordForm.tsx
@@ -68,10 +68,10 @@ function PasswordForm({ hidden, myId, channelId }: PasswordFormProps) {
         </label>
       </form>
       <div className="formModalButtons">
-        <button type="submit" form="joinChat">
+        <button className='formModalConfirm regular' type="submit" form="createChat" onClick={handleSubmit}>
           확인
         </button>
-        <button onClick={() => hidden()}>취소</button>
+        <button className='formModalCancel regular' onClick={hidden}>취소</button>
       </div>
     </>
   );

--- a/frontend/src/components/chats/interface.ts
+++ b/frontend/src/components/chats/interface.ts
@@ -2,7 +2,7 @@ export interface ChannelInfo {
   channelId: number;
   channelName: string;
   memberCount: number;
-  accessMode: string;
+  accessMode: "public" | "protected" | "private";
   isDm?: boolean;
   unseenCount?: number;
 }

--- a/frontend/src/style/Chats.css
+++ b/frontend/src/style/Chats.css
@@ -1,101 +1,169 @@
 .chats {
   display: grid;
+  color: var(--primary_dark);
+  height: calc(100vh - 50px);
   grid-template-columns:
     1fr minmax(auto, 500px) 5% minmax(auto, 500px)
     1fr;
   grid-template-rows: 10% 75% 15%;
-  height: calc(100vh - 50px);
   width: 100%;
 }
 
 .chatsJoined {
-  grid-row: 2;
   grid-column: 2;
+  grid-row: 2;
 }
 
 .chatsAll {
-  grid-row: 2;
   grid-column: 4;
+  grid-row: 2;
 }
 
 .chatsFrame {
-  background-color: transparent;
   display: flex;
   flex-direction: column;
   height: 100%;
 }
 
 .chatsHeader {
-  position: relative;
-  display: flex;
   align-items: center;
-  justify-content: center;
-  min-height: 80px;
-  height: 80px;
-  background-color: var(--secondary);
+  background-color: var(--primary);
+  color: var(--secondary);
   border-radius: 10px 10px 0 0;
+  box-shadow: 0rem 0.3rem 0.2rem rgba(0, 0, 0, 0.125);
+  display: flex;
+  height: 80px;
+  justify-content: center;
+  z-index: 2;
 }
 
-.chatsNewButton {
-  position: absolute;
-  top: 50%;
-  right: 10px;
-  transform: translateY(-50%);
+.chatsListSpin {
+  animation: rotation 1s linear infinite;
+  border-radius: 50%;
+  border-right: 3px solid transparent;
+  border-top: 3px solid var(--secondary);
+  height: 2rem;
+  margin: auto;
+  width: 2rem;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .chatsBody {
-  height: calc(100% - 80px);
+  align-items: center;
   background-color: var(--secondary_light);
   border-radius: 0 0 10px 10px;
+  display: flex;
+  flex-direction: column;
+  height: calc(100% - 80px);
   overflow-y: auto;
+  padding: 1rem;
+  position: relative;
+  row-gap: 1rem;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE 10+ */
+}
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.chatsBody::-webkit-scrollbar {
+  display: none;
+}
+
+.chatsNewButton {
+  align-self: flex-end;
+  background-color: var(--primary_dark);
+  border-radius: 50%;
+  width: 4rem;
+  height: 4rem;
+  min-height: 4rem;
+  bottom: 0;
+  box-shadow: 0.1rem 0.15rem rgba(0, 0, 0, 0.25);
+  color: var(--secondary);
+  position: sticky;
+  transition: all 0.4s linear;
+}
+
+.chatsNewButton:hover,
+.chatsNewButton:focus {
+  background-color: var(--secondary);
+  color: var(--primary_dark);
+  filter: brightness(1.05);
 }
 
 /** SECTION: channel component */
 
 .channel {
-  display: grid;
-  grid-template-columns: repeat(1fr, 3);
-  grid-template-rows: repeat(1fr, 2);
-  grid-template-areas: 'name name name' 'members unseen accessMode';
-  padding: 10px;
-  margin: 10px;
+  align-items: center;
+  background-color: var(--secondary);
   border-radius: 10px;
   cursor: pointer;
-  transition: 0.2s;
-  background-color: var(--secondary);
+  display: grid;
+  grid-template-areas: 'name empty unseen' 'name accessMode members';
+  grid-template-columns: 7fr 0.5fr 1.2fr;
+  grid-template-rows: 1fr 1fr;
+  min-height: 3rem;
+  padding: 1rem;
   text-decoration: none;
+  transition: 0.8s;
+  width: calc(100% - 40px);
+  color: var(--primary);
+  box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.25);
 }
 
-.channelName,
+.channel:hover,
+.channel:active {
+  background-color: var(--primary);
+  color: var(--secondary);
+}
+
+.channelSvgIcon > path {
+  transition: 0.8s;
+}
+
+.channel:hover .channelSvgIcon > path,
+.channel:active .channelSvgIcon > path {
+  stroke: var(--secondary);
+}
+
 .channelUnseen,
-.channelMemberCount,
-.channelAccessMode {
-  display: flex;
+.channelMember,
+.channelAccessMode,
+.channelDm {
   align-items: center;
-  justify-content: center;
-  color: var(--primary);
-  background-color: var(--secondary);
+  display: flex;
+  margin-left: 0.5rem;
+}
+
+.channelDm {
+  grid-area: dm;
 }
 
 .channelName {
+  display: block;
   grid-area: name;
+  overflow: hidden;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .channelUnseen {
   grid-area: unseen;
 }
 
-.channelMemberCount {
+.channelMember {
   grid-area: members;
 }
 
 .channelAccessMode {
   grid-area: accessMode;
-}
-
-.channelDm {
-  background-color: var(--secondary);
-  filter: grayscale(100%);
 }
 
 /** SECTION: responsive */
@@ -108,13 +176,13 @@
   }
 
   .chatsJoined {
-    grid-row: 2;
     grid-column: 2;
+    grid-row: 2;
   }
 
   .chatsAll {
-    grid-row: 4;
     grid-column: 2;
+    grid-row: 4;
   }
 
   .chatsFrame {

--- a/frontend/src/style/FormModal.css
+++ b/frontend/src/style/FormModal.css
@@ -29,13 +29,37 @@
   display: grid;
   align-items: center;
   grid-template-rows: 4rem 1fr 3.5rem;
-  max-height: 50%;
-  min-height: 40%;
   min-width: 32em;
-  position: absolute;
-  width: 25%;
-  z-index: 12;
   padding: 0 0 1.25rem;
+  position: absolute;
+  width: 20%;
+  z-index: 12;
+}
+
+.formModalAnimation {
+  animation-duration: 0.3s;
+  animation-delay: 0s;
+  animation-direction: normal;
+  animation-timing-function: ease;
+  animation-iteration-count: 1;
+  animation-fill-mode: none;
+  animation-play-state: running;
+  animation-name: formModalShow;
+}
+
+@keyframes formModalShow {
+  0% {
+    transform: scale(0.7);
+  }
+  45% {
+    transform: scale(1.05);
+  }
+  80% {
+    transform: scale(0.95);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 .formModalTitle {
@@ -49,23 +73,24 @@
 }
 
 .formModalBody {
+  align-content: center;
+  align-content: space-evenly;
   display: grid;
   width: 100%;
   height: 100%;
   justify-items: start;
   justify-content: center;
-  align-content: center;
-  align-content: space-evenly;
 }
 
 .formModalField {
+  align-items: center;
+  column-gap: 10px;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  column-gap: 10px;
   height: 2rem;
-  width: 100%;
-  align-items: center;
   justify-items: center;
+  margin: 2rem 0;
+  width: 100%;
 }
 
 .formModalFieldName {
@@ -109,18 +134,18 @@
 }
 
 .formModalButtons {
+  align-items: center;
   display: flex;
   justify-content: center;
-  align-items: center;
   height: 100%;
 }
 
 .formModalConfirm,
 .formModalCancel {
-  margin: 0.3125em;
-  padding: 0.625em 1.1em;
   border-radius: 0.25rem;
+  margin: 0.3125em;
   outline: none;
+  padding: 0.625em 1.1em;
 }
 
 .formModalConfirm:hover,

--- a/frontend/src/style/FormModal.css
+++ b/frontend/src/style/FormModal.css
@@ -1,14 +1,14 @@
 .formModal {
-  height: 100vh;
-  width: 100vw;
   align-items: center;
   display: flex;
   flex-direction: column;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
   position: absolute;
   top: 0;
-  left: 0;
+  width: 100vw;
   z-index: 10;
-  justify-content: center;
 }
 
 .formModalOverlay {
@@ -28,18 +28,20 @@
   color: var(--secondary_light);
   display: grid;
   align-items: center;
-  grid-template-rows: 3.5rem 1fr 2rem;
+  grid-template-rows: 4rem 1fr 3.5rem;
   max-height: 50%;
-  min-height: 20%;
-  min-width: 400px;
+  min-height: 40%;
+  min-width: 32em;
   position: absolute;
-  width: 30%;
+  width: 25%;
   z-index: 12;
+  padding: 0 0 1.25rem;
 }
 
 .formModalTitle {
   display: flex;
   align-items: center;
+  color: var(--secondary_light);
   justify-content: center;
   font-weight: 600;
   height: 100%;
@@ -48,26 +50,92 @@
 
 .formModalBody {
   display: grid;
-  margin: 20px 0;
   width: 100%;
   height: 100%;
   justify-items: start;
   justify-content: center;
   align-content: center;
-  row-gap: 40px;
+  align-content: space-evenly;
 }
 
 .formModalField {
   display: grid;
   grid-template-columns: 1fr 1fr;
   column-gap: 10px;
+  height: 2rem;
   width: 100%;
+  align-items: center;
+  justify-items: center;
+}
+
+.formModalFieldName {
+  align-items: center;
+  background: var(--primary_dark);
+  border-radius: 10px 10px 0 0;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  width: 100%;
+}
+
+.formModalFieldValue {
+  align-items: center;
+  background: var(--primary);
+  border: solid 3px var(--secondary_dark);
+  border-radius: 3px;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  position: relative;
+}
+
+.formModalFieldError {
+  position: absolute;
+  bottom: -2rem;
+}
+
+.formModalFieldValue:hover,
+.formModalFieldValue:focus-within {
+  border: solid 3px var(--secondary);
+}
+
+.formModalFieldInput {
+  background: var(--primary);
+  border-width: 0;
+  color: var(--secondary_light);
+  margin: 0 10px;
+  outline: none;
+  padding: 0;
 }
 
 .formModalButtons {
   display: flex;
-  justify-content: space-evenly;
+  justify-content: center;
   align-items: center;
-  width: 100%;
   height: 100%;
+}
+
+.formModalConfirm,
+.formModalCancel {
+  margin: 0.3125em;
+  padding: 0.625em 1.1em;
+  border-radius: 0.25rem;
+  outline: none;
+}
+
+.formModalConfirm:hover,
+.formModalCancel:hover,
+.formModalConfirm:focus,
+.formModalCancel:focus {
+  filter: brightness(0.9);
+}
+
+.formModalConfirm {
+  background: var(--secondary);
+  color: var(--primary_dark);
+}
+
+.formModalCancel {
+  background: var(--primary);
+  color: var(--secondary_light);
 }

--- a/frontend/src/style/presets/Alert.css
+++ b/frontend/src/style/presets/Alert.css
@@ -6,13 +6,13 @@
 }
 
 /* SECTION : SweetAlert custom css */
-.swal2-confirm-custom {
+.swal2ConfirmCustom {
   background-color: var(--secondary) !important;
   color: var(--primary_dark) !important;
 }
 
-.swal2-cancel-custom,
-.swal2-deny-custom {
-  background-color: var(--primary_dark) !important;
+.swal2CancelCustom,
+.swal2DenyCustom {
+  background-color: var(--primary) !important;
   color: var(--secondary_light) !important;
 }

--- a/frontend/src/style/presets/reset.css
+++ b/frontend/src/style/presets/reset.css
@@ -130,14 +130,6 @@ table {
 
 /* css reset by google.com */
 
-html,
-body,
-h1,
-input,
-select {
-  font-family: 'Apple SD Gothic Neo', arial, sans-serif;
-}
-
 button {
   margin: 0;
 }

--- a/frontend/src/util/Alert.ts
+++ b/frontend/src/util/Alert.ts
@@ -4,9 +4,9 @@ import '../style/presets/Alert.css'
 
 export const ReactSwal = withReactContent(Swal).mixin({
   customClass: {
-    confirmButton: 'swal2-confirm-custom',
-    denyButton: 'swal2-deny-custom',
-    cancelButton: 'swal2-cancel-custom',
+    confirmButton: 'swal2ConfirmCustom',
+    denyButton: 'swal2DenyCustom',
+    cancelButton: 'swal2CancelCustom',
   },
 });
 

--- a/frontend/src/views/Chats.tsx
+++ b/frontend/src/views/Chats.tsx
@@ -5,6 +5,8 @@ import ChatsBody from '../components/chats/ChatsBody';
 import instance from '../util/Axios';
 import socket from '../util/Socket';
 import '../style/Chats.css';
+import { AxiosError } from 'axios';
+import { ErrorAlert } from '../util/Alert';
 
 function Chats() {
   const [joinedChannels, setJoinedChannels] = useState<
@@ -13,7 +15,6 @@ function Chats() {
   const [otherChannels, setOtherChannels] = useState<Channels['otherChannels']>(
     [],
   );
-  // const [error, setError] = useState<string>('');
 
   useEffect(() => {
     (async () => {
@@ -26,13 +27,12 @@ function Chats() {
         ).data;
         setJoinedChannels(joinedChannels);
         setOtherChannels(otherChannels);
-      } catch (err: any) {
-        console.log(err);
-        // TODO:  error handling 및 채널이 없을 시 적절한 메시지 렌더링
+      } catch (err) {
+        ErrorAlert('채널 목록 로딩 실패', '오류가 발생했습니다.');
       }
     })();
   }, []);
-  // TODO : 누군가 채널 생성시 socket event 로 추가하기
+
   return (
     <div className="chats">
       <ChatsFrame purpose={'chatsJoined'}>


### PR DESCRIPTION
## 개요
- #188 완료
- #189 완료
## 작업 사항
- Axios 성공 / 실패시 적절한 모달 추가
- Chats UI / FormModal 에 Style 및 Animation 적용
  - SweetAlert2 와 최대한 유사하게 하려고 했지만... 모달이 닫힐 때 Animation 구현은 실패했습니다. 방법은 있는데 좀... 복잡합니다.
- svg 를 코드 가독성을 유지하며 사용하기 위해 Component 로 Wrapping 해서 사용했습니다. 추후에 search 에 있는 svg 도 업데이트 해두겠습니다.
  - 재사용성을 위해서 일단은 svg component 에 prop 으로 여러 속성을 받아두었습니다. 
- 알림은 999개 이상 쌓이면 999+ 로 렌더링 되도록 하였습니다. 제한을 두지 않으면 UI 가 깨질 위험이 있습니다.
## 변경점
- 이미 접속한 채널 / 공개 채널을 클릭하면 바로 입장하도록 구현되어 있었는데, 모달 창을 거쳐서 입장하는 것으로 변경했습니다. 의도치 않게 잘못눌러서 들어가면 당황스러울 것 같았습니다... ㅎ

## 스크린샷 (optional)
<img width="2672" alt="Screen Shot 2023-03-03 at 2 41 59 PM" src="https://user-images.githubusercontent.com/79127797/222642212-3ba76a38-44a8-4fd6-b24a-608731f75893.png">
