### PR TITLE
:sparkles: feat : 게임 종료 후 UX 개선

### DIFF
--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon';
 import { IncomingMessage } from 'http';
 import { Request } from 'express';
 import { Socket } from 'socket.io';
+import { Subscription } from 'rxjs';
 
 export type UserId = number;
 
@@ -50,46 +51,27 @@ export type Activity = 'online' | 'offline' | 'inGame';
 export type Score = 0 | 1 | 2 | 3 | 4 | 5;
 
 export class BallCoordinates {
-  constructor(x = 0.5, y = 0.5) {
-    this.x = x;
-    this.y = y;
-  }
-
-  x: number;
-  y: number;
+  x = 0.5;
+  y = 0.5;
 }
 
 export class BallVelocity {
-  constructor(vx = 0.004, vy = 0.004) {
-    this.vx = vx;
-    this.vy = vy;
-  }
-
-  vx: number;
-  vy: number;
+  vx = 0.004;
+  vy = 0.004;
 }
 
 export class PaddlePositions {
-  constructor(leftY = 0.5 - 0.08333, rightY = 0.5 - 0.08333) {
-    this.leftY = leftY;
-    this.rightY = rightY;
-  }
-
-  leftY: number;
-  rightY: number;
+  leftY = 0.5 - 0.08333;
+  rightY = 0.5 - 0.08333;
 }
 
 export class GameData {
-  constructor() {
-    this.ballCoords = new BallCoordinates();
-    this.ballVelocity = new BallVelocity();
-    this.paddlePositions = new PaddlePositions();
-    this.scores = [0, 0];
-  }
-  ballCoords: BallCoordinates;
-  ballVelocity: BallVelocity;
-  paddlePositions: PaddlePositions;
-  scores: [Score, Score];
+  ballCoords = new BallCoordinates();
+  ballVelocity = new BallVelocity();
+  intervalId: NodeJS.Timer | null = null;
+  paddlePositions = new PaddlePositions();
+  scores: [Score, Score] = [0, 0];
+  subscription: Subscription | null = null;
 }
 
 export class GameInfo {
@@ -103,8 +85,6 @@ export class GameInfo {
     this.rightId = rightId;
     this.map = map;
     this.isRank = isRank;
-    this.isStarted = false;
-    this.gameData = new GameData();
   }
 
   isRank: boolean;
@@ -113,8 +93,8 @@ export class GameInfo {
   rightId: UserId;
   rightNickname?: string;
   map: 1 | 2 | 3;
-  isStarted: boolean;
-  gameData: GameData;
+  isStarted = false;
+  gameData = new GameData();
 }
 
 // SECTION : User verification

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,6 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.0",
         "recoil": "^0.7.6",
-        "rxjs": "^7.8.0",
         "socket.io-client": "^4.6.0",
         "sweetalert2": "^11.7.3",
         "sweetalert2-react-content": "^5.0.7"
@@ -4184,19 +4183,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-    },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
@@ -7676,21 +7662,6 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-      "requires": {
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
-        }
       }
     },
     "safe-regex-test": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,6 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.0",
     "recoil": "^0.7.6",
-    "rxjs": "^7.8.0",
     "socket.io-client": "^4.6.0",
     "sweetalert2": "^11.7.3",
     "sweetalert2-react-content": "^5.0.7"

--- a/frontend/src/components/GameRoom/GameMenu.tsx
+++ b/frontend/src/components/GameRoom/GameMenu.tsx
@@ -1,10 +1,4 @@
-export default function GameMenu({
-  isRank,
-  isOwner,
-  startGame,
-}: GameMenuProps) {
-  const handleStartClick = () => startGame();
-
+export default function GameMenu({ gameId, isRank, isOwner }: GameMenuProps) {
   const handleMapClick = () => {};
 
   return (
@@ -13,7 +7,9 @@ export default function GameMenu({
         <button
           className="gameButton gameStartButton"
           type="button"
-          onClick={handleStartClick}
+          onClick={() =>
+            sessionStorage.setItem(`game-${gameId}-isStarted`, 'true')
+          }
         >
           START GAME
         </button>
@@ -30,7 +26,7 @@ export default function GameMenu({
 // SECTION : Interfaces
 
 interface GameMenuProps {
+  gameId: string;
   isRank: boolean;
   isOwner: boolean;
-  startGame: () => void;
 }

--- a/frontend/src/components/GameRoom/GamePlay.tsx
+++ b/frontend/src/components/GameRoom/GamePlay.tsx
@@ -1,17 +1,24 @@
 import { ControllerType, GameInfo } from './util/interfaces';
-import { useRef } from 'react';
 import { useCanvasResize } from './hooks/GameResizeHooks';
 import { useGamePlay } from './hooks/GamePlayHooks';
+import { useLayoutEffect, useRef, useState } from 'react';
 
-export default function GamePlay({
-  gameInfo,
-  controllerType,
-  isStarted,
-}: GamePlayProps) {
+export default function GamePlay({ gameInfo, controllerType }: GamePlayProps) {
   const parentRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const dimensions = useCanvasResize(parentRef);
-  useGamePlay(canvasRef, gameInfo, controllerType, dimensions);
+  const [isStarted, setIsStarted] = useState(
+    sessionStorage.getItem(`game-${gameInfo.id}-isStarted`) === 'true',
+  );
+  useLayoutEffect(() => {
+    const intervalId = setInterval(() => {
+      if (sessionStorage.getItem(`game-${gameInfo.id}-isStarted`) === 'true') {
+        clearInterval(intervalId);
+        setIsStarted(true);
+      }
+    }, 100);
+  }, []);
+  useGamePlay(isStarted, canvasRef, gameInfo, controllerType, dimensions);
   return (
     <div className="gamePlay" ref={parentRef}>
       {isStarted && (
@@ -31,5 +38,4 @@ export default function GamePlay({
 interface GamePlayProps {
   gameInfo: GameInfo;
   controllerType: ControllerType;
-  isStarted: boolean;
 }

--- a/frontend/src/components/GameRoom/hooks/GameDataHooks.tsx
+++ b/frontend/src/components/GameRoom/hooks/GameDataHooks.tsx
@@ -1,39 +1,34 @@
 import { ErrorAlert } from '../../../util/Alert';
 import instance from '../../../util/Axios';
-import { listenEvent, socket } from '../../../util/Socket';
+import { listenOnce } from '../../../util/Socket';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-export function useListenGameEvents(isConnected: boolean, isPlayer: boolean) {
-  const nav = useNavigate();
-
-  useEffect(() => {
-    if (isConnected) {
-      listenEvent('gameAborted').then(() => {
-        ErrorAlert(
-          '게임 중단',
-          isPlayer
-            ? '상대방이 게임을 중단했습니다.<br/>당신의 승리로 기록되었습니다!'
-            : '게임이 중단되었습니다.',
-        );
-        nav('/waiting-room'); // NOTE : 일반 게임일 때도?
-      });
-    }
-    return () => {
-      socket.off('gameAborted');
-    };
-  }, []);
-}
-
-export function useRequestGame(
-  isConnected: boolean,
-  isPlayer: boolean,
-  gameId: string,
-  setIsStarted: React.Dispatch<React.SetStateAction<boolean>>,
-) {
+export function useRequestGame(isConnected: boolean, gameId: string) {
   const [gameInfo, setGameInfo] = useState<GameInfoData | null>(null);
   const [players, setPlayers] = useState<[string, string] | null>(null);
   const nav = useNavigate();
+
+  const listenGameAbortedOnce = (isLeft: boolean | null = null) => {
+    listenOnce<{ abortedSide: 'left' | 'right' }>('gameAborted').then(
+      ({ abortedSide }) => {
+        console.log('isLeft', isLeft);
+        const message =
+          isLeft !== null
+            ? (isLeft && abortedSide === 'right') ||
+              (!isLeft && abortedSide === 'left')
+              ? '상대방이 게임을 중단했습니다.<br/>당신의 승리로 기록되었습니다!'
+              : '게임을 중단했습니다.<br/>당신의 패배로 기록되었습니다.'
+            : '게임이 중단되었습니다.';
+        ErrorAlert('게임 중단', message);
+        if (window.location.pathname === `/game/${gameId}`) {
+          nav('/waiting-room'); // NOTE : 일반 게임일 때도?
+        }
+        sessionStorage.removeItem(`game-${gameId}-isStarted`);
+        sessionStorage.removeItem(`game-${gameId}-isPlayer`);
+      },
+    );
+  };
 
   const requestGameStart = async () => {
     let isRank = false;
@@ -48,14 +43,14 @@ export function useRequestGame(
           ? [data.playerNickname, data.opponentNickname]
           : [data.opponentNickname, data.playerNickname],
       );
+      listenGameAbortedOnce(data.isLeft);
     } catch (e) {
       ErrorAlert('게임 정보 요청', '게임 정보를 가져오는데 실패했습니다.');
       nav('/waiting-room');
       return;
     }
     try {
-      listenEvent('gameCancelled').then(() => {
-        socket.off('gameCancelled');
+      listenOnce('gameCancelled').then(() => {
         ErrorAlert(
           '게임 취소',
           '상대방이 게임에 접속하지 않아 취소되었습니다.',
@@ -64,7 +59,7 @@ export function useRequestGame(
       });
       await instance.patch(`/game/${gameId}/start`);
       if (isRank) {
-        setIsStarted(true);
+        sessionStorage.setItem(`game-${gameId}-isStarted`, 'true');
       }
     } catch (e) {
       ErrorAlert('게임 시작', '게임을 시작하는데 실패했습니다.');
@@ -77,7 +72,10 @@ export function useRequestGame(
       const { data } = await instance.get(`/game/list/${gameId}`);
       setGameInfo(data);
       setPlayers([data.leftPlayer, data.rightPlayer]);
-      data.isRank && setIsStarted(true);
+      if (data.isRank) {
+        sessionStorage.setItem(`game-${gameId}-isStarted`, 'true');
+      }
+      listenGameAbortedOnce();
     } catch (e) {
       ErrorAlert('관전 요청', '관전 요청이 실패했습니다.');
       nav('/waiting-room');
@@ -85,11 +83,18 @@ export function useRequestGame(
   };
 
   useEffect(() => {
-    isConnected && isPlayer ? requestGameStart() : requestSpectate();
+    if (isConnected) {
+      sessionStorage.getItem(`game-${gameId}-isPlayer`) === 'true'
+        ? requestGameStart()
+        : requestSpectate();
+    }
     return () => {
-      isPlayer && socket.off('gameCancelled');
+      setTimeout(() => {
+        sessionStorage.removeItem(`game-${gameId}-isStarted`);
+        sessionStorage.removeItem(`game-${gameId}-isPlayer`);
+      }, 1000);
     };
-  }, []);
+  }, [isConnected]);
   return { gameInfo, players };
 }
 

--- a/frontend/src/components/GameRoom/hooks/GamePlayHooks.tsx
+++ b/frontend/src/components/GameRoom/hooks/GamePlayHooks.tsx
@@ -2,14 +2,21 @@ import { ControllerType, Dimensions, GameInfo } from '../util/interfaces';
 import { GamePainter } from '../util/GamePainter';
 import { socket } from '../../../util/Socket';
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export function useGamePlay(
+  isStarted: boolean,
   canvasRef: React.RefObject<HTMLCanvasElement>,
   gameInfo: GameInfo,
   controllerType: ControllerType,
   dimensions: Dimensions,
 ) {
+  const nav = useNavigate();
+
   useEffect(() => {
+    if (!isStarted) {
+      return;
+    }
     const keyDownHandler = (e: KeyboardEvent) => {
       if (e.key === 'Up' || e.key === 'ArrowUp') {
         e.preventDefault();
@@ -38,6 +45,7 @@ export function useGamePlay(
           gameInfo,
           controllerType,
           dimensions,
+          nav,
         );
         if (controllerType.isPlayer) {
           document.addEventListener('keydown', keyDownHandler);

--- a/frontend/src/components/GameRoom/util/GamePainter.ts
+++ b/frontend/src/components/GameRoom/util/GamePainter.ts
@@ -7,6 +7,7 @@ import {
   PaddlePositions,
   Score,
 } from './interfaces';
+import { NavigateFunction } from 'react-router-dom';
 import { socket } from '../../../util/Socket';
 
 export class GamePainter {
@@ -17,6 +18,7 @@ export class GamePainter {
     private readonly gameInfo: GameInfo,
     private readonly controllerType: ControllerType,
     private readonly dimension: { w: number; h: number },
+    private readonly nav: NavigateFunction,
   ) {
     this.context.font = '4rem DungGeunMo';
     this.metaData = new GameMetaData(dimension);
@@ -44,6 +46,13 @@ export class GamePainter {
       ({ winnerSide }: { winnerSide: 'left' | 'right' }) => {
         socket.off('gameData');
         this.drawResult(winnerSide);
+        sessionStorage.removeItem(`game-${this.gameInfo.id}-isStarted`);
+        sessionStorage.removeItem(`game-${this.gameInfo.id}-isPlayer`);
+        setTimeout(() => {
+          if (window.location.pathname === `/game/${this.gameInfo.id}`) {
+            this.nav('/waiting-room');
+          }
+        }, 5000);
       },
     );
   }

--- a/frontend/src/components/WaitingRoom/GameInProgressButton.tsx
+++ b/frontend/src/components/WaitingRoom/GameInProgressButton.tsx
@@ -24,7 +24,10 @@ export default function GameInProgressButton({
   const handleMouseMove = (e: MouseEvent) =>
     setHoverInfoCoords({ x: e.clientX + 8, y: e.clientY + 20 });
 
-  const handleClick = () => nav(`/game/${gameId}`);
+  const handleClick = () => {
+    nav(`/game/${gameId}`);
+    sessionStorage.setItem(`game-${gameId}-isPlayer`, 'false');
+  };
 
   return (
     <>

--- a/frontend/src/components/WaitingRoom/GameQueueButton.tsx
+++ b/frontend/src/components/WaitingRoom/GameQueueButton.tsx
@@ -1,6 +1,6 @@
 import { ErrorAlert } from '../../util/Alert';
 import instance from '../../util/Axios';
-import { listenEvent, socket } from '../../util/Socket';
+import { listenOnce } from '../../util/Socket';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
@@ -10,19 +10,15 @@ export default function GameEnterQueueButton() {
 
   const handleButtonClick = () => {
     hasEnteredQueue
-      ? instance
-          .delete('/game/queue')
-          .then(() => setHasEnteredQueue(false))
-          .catch(err => {
-            // NOTE : 서버에서 에러가 날 케이스가 없을 것으로 보이는데 한번 더 확인 필요
-          })
+      ? instance.delete('/game/queue').then(() => setHasEnteredQueue(false))
       : instance
           .post('/game/queue')
           .then(() => {
             setHasEnteredQueue(true);
-            listenEvent<NewGameMessage>('newGame').then(({ gameId }) =>
-              nav(`/game/${gameId}`, { state: { isPlayer: true } }),
-            );
+            listenOnce<NewGameMessage>('newGame').then(({ gameId }) => {
+              nav(`/game/${gameId}`);
+              sessionStorage.setItem(`game-${gameId}-isPlayer`, 'true');
+            });
           })
           .catch(err => {
             switch (err.response.status) {

--- a/frontend/src/components/hooks/EmitCurrentUi.tsx
+++ b/frontend/src/components/hooks/EmitCurrentUi.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { listenEvent, socket } from '../../util/Socket';
+import { listenOnce, socket } from '../../util/Socket';
 
 export function useCurrentUi(
   isConnected: boolean,
@@ -9,7 +9,7 @@ export function useCurrentUi(
   useEffect(() => {
     isConnected
       ? socket.emit('currentUi', { ui })
-      : listenEvent('connect').then(() => {
+      : listenOnce('connect').then(() => {
           socket.emit('currentUi', { ui });
           setIsConnected(true);
         });

--- a/frontend/src/util/Recoils.ts
+++ b/frontend/src/util/Recoils.ts
@@ -1,9 +1,9 @@
-import { atom, atomFamily, selector } from 'recoil';
-import instance from './Axios';
 import {
   activityData,
   relationshipData,
 } from '../components/hooks/SocketOnHooks';
+import { atom, atomFamily, selector } from 'recoil';
+import instance from './Axios';
 
 export const myIdState = atom<number>({
   key: 'myIdState',

--- a/frontend/src/util/Socket.ts
+++ b/frontend/src/util/Socket.ts
@@ -8,5 +8,5 @@ export const socket = io('http://localhost:3000', {
   withCredentials: true,
 });
 
-export const listenEvent = <T>(event: string) =>
-  new Promise<T>(resolve => socket.on(event, resolve));
+export const listenOnce = <T>(event: string) =>
+  new Promise<T>(resolve => socket.once(event, resolve));

--- a/frontend/src/views/GameRoom.tsx
+++ b/frontend/src/views/GameRoom.tsx
@@ -3,30 +3,20 @@ import GameMenu from '../components/GameRoom/GameMenu';
 import GamePlay from '../components/GameRoom/GamePlay';
 import { socket } from '../util/Socket';
 import { useCurrentUi } from '../components/hooks/EmitCurrentUi';
-import {
-  useListenGameEvents,
-  useRequestGame,
-} from '../components/GameRoom/hooks/GameDataHooks';
-import { useLocation, useParams } from 'react-router-dom';
+import { useRequestGame } from '../components/GameRoom/hooks/GameDataHooks';
+import { useParams } from 'react-router-dom';
 import { useState } from 'react';
 import '../style/GameRoom.css';
 
 export default function GameRoom() {
   const { gameId } = useParams();
-  if (gameId === undefined) return;
-  const location = useLocation();
+  if (gameId === undefined) {
+    return;
+  }
   const [isConnected, setIsConnected] = useState(socket.connected);
-  const [isStarted, setIsStarted] = useState(false);
-  const isPlayer = location.state?.isPlayer ?? false;
 
   useCurrentUi(isConnected, setIsConnected, `game-${gameId}`);
-  const { gameInfo, players } = useRequestGame(
-    isConnected,
-    isPlayer,
-    gameId,
-    setIsStarted,
-  );
-  useListenGameEvents(isConnected, isPlayer);
+  const { gameInfo, players } = useRequestGame(isConnected, gameId);
 
   return (
     <div className="gameRoom">
@@ -39,13 +29,16 @@ export default function GameRoom() {
           />
           <GamePlay
             gameInfo={{ id: gameId, players }}
-            controllerType={{ isLeft: gameInfo.isLeft, isPlayer }}
-            isStarted={isStarted}
+            controllerType={{
+              isLeft: gameInfo.isLeft,
+              isPlayer:
+                sessionStorage.getItem(`game-${gameId}-isPlayer`) === 'true',
+            }}
           />
           <GameMenu
+            gameId={gameId}
             isRank={gameInfo.isRank}
             isOwner={gameInfo.isLeft}
-            startGame={() => setIsStarted(true)}
           />
         </>
       )}


### PR DESCRIPTION
## 개요
- #216 해결.
- #217 완료.

## 작업 사항
- 게임 비정상 종료 시 서버에서 게임 엔진이 멈추도록 수정.
- 게임 비정상 종료 시 클라이언트 사이드에서 승자, 패자, 관전자에게 에러 메시지 상황에 맞게 설정.
- 게임 종료 후 waitingRoom 으로 이동.
- isPlayer, isStarted 상태가 새로고침 후에도 필요한 경우가 있어서 sessionStorage 에 저장했습니다.

close #216 
close #217 