### PR TITLE
✨ feat : 채팅방 내부 기능 추가

### DIFF
--- a/backend/src/chats/chats.controller.ts
+++ b/backend/src/chats/chats.controller.ts
@@ -19,6 +19,7 @@ import {
 import { ChatsService } from './chats.service';
 import { ChannelExistGuard } from './guard/channel-exist.guard';
 import { ChannelId, UserId, VerifiedRequest } from '../util/type';
+import { ChannelOwnerGuard } from './guard/channel-owner.guard';
 import {
   CreateChannelDto,
   JoinChannelDto,
@@ -33,7 +34,6 @@ import { MessageTransformPipe } from './pipe/message-transform.pipe';
 import { Response } from 'express';
 import { ValidateChannelInfoPipe } from './pipe/validate-channel-info.pipe';
 import { ValidateRangePipe } from '../pipe/validate-range.pipe';
-import { ChannelOwnerGuard } from './guard/channel-owner.guard';
 
 const RANGE_LIMIT_MAX = 10000;
 

--- a/backend/src/chats/chats.gateway.ts
+++ b/backend/src/chats/chats.gateway.ts
@@ -115,6 +115,28 @@ export class ChatsGateway {
   }
 
   /**
+   * @description 채널이 public | protected 로 변경 되었을 때, chats-UI 를 보고 있는 유저에게 알림
+   *
+   * @param channelId 변경된 채널
+   * @param channelName 채널의 이름
+   * @param accessMode 변경된 채널의 접근 권한
+   * @param memberCount 채널의 참여 인원
+   */
+  emitChannelShown(
+    channelId: ChannelId,
+    channelName: string,
+    accessMode: 'public' | 'protected',
+    memberCount: number,
+  ) {
+    this.server.in('chats').emit('channelShown', {
+      channelId,
+      channelName,
+      memberCount,
+      accessMode,
+    });
+  }
+
+  /**
    * @description 채널이 private 로 변경 되었을 때, chats-UI 를 보고 있는 유저에게 알림
    *
    * @param channelId 변경된 채널

--- a/backend/src/chats/chats.gateway.ts
+++ b/backend/src/chats/chats.gateway.ts
@@ -98,6 +98,31 @@ export class ChatsGateway {
     });
   }
 
+  /**
+   * @description 채널에 멤버가 추가/삭제 되었을 때, chats-UI 를 보고 있는 유저에게 알림
+   *
+   * @param channelId 참여 인원 변동이 일어난 채널
+   * @param memberCountDiff 참여 인원 변동량
+   */
+  emitChannelUpdated(
+    channelId: ChannelId,
+    memberCountDiff: -1 | 0 | 1 = 0,
+    accessMode: 'public' | 'protected' | 'private' | null = null,
+  ) {
+    this.server
+      .in('chats')
+      .emit('channelUpdated', { channelId, memberCountDiff, accessMode });
+  }
+
+  /**
+   * @description 채널이 삭제 되었을 때, chats-UI 를 보고 있는 유저에게 알림
+   *
+   * @param channelId 삭제된 채널
+   */
+  emitChannelDeleted(channelId: ChannelId) {
+    this.server.in('chats').emit('channelDeleted', { channelId });
+  }
+
   /*****************************************************************************
    *                                                                           *
    * SECTION : Events when user does viewing the chatRoom-UI                   *
@@ -245,32 +270,5 @@ export class ChatsGateway {
       .in(`chatRooms-${channelId}`)
       .except(`chatRooms-${channelId}-active`)
       .emit('messageArrived', { channelId });
-  }
-
-  /*****************************************************************************
-   *                                                                           *
-   * SECTION : Events when user does viewing the chats-UI                      *
-   *                                                                           *
-   ****************************************************************************/
-
-  /**
-   * @description 채널에 멤버가 추가/삭제 되었을 때, chats-UI 를 보고 있는 유저에게 알림
-   *
-   * @param channelId 참여 인원 변동이 일어난 채널
-   * @param memberCountDiff 참여 인원 변동량
-   */
-  private emitChannelUpdated(channelId: ChannelId, memberCountDiff: number) {
-    this.server
-      .in('chats')
-      .emit('channelUpdated', { channelId, memberCountDiff });
-  }
-
-  /**
-   * @description 채널이 삭제 되었을 때, chats-UI 를 보고 있는 유저에게 알림
-   *
-   * @param channelId 삭제된 채널
-   */
-  private emitChannelDeleted(channelId: ChannelId) {
-    this.server.in('chats').emit('channelDeleted', { channelId });
   }
 }

--- a/backend/src/chats/chats.gateway.ts
+++ b/backend/src/chats/chats.gateway.ts
@@ -115,12 +115,12 @@ export class ChatsGateway {
   }
 
   /**
-   * @description 채널이 삭제 되었을 때, chats-UI 를 보고 있는 유저에게 알림
+   * @description 채널이 private 로 변경 되었을 때, chats-UI 를 보고 있는 유저에게 알림
    *
-   * @param channelId 삭제된 채널
+   * @param channelId 변경된 채널
    */
-  emitChannelDeleted(channelId: ChannelId) {
-    this.server.in('chats').emit('channelDeleted', { channelId });
+  emitChannelHidden(channelId: ChannelId) {
+    this.server.in('chats').emit('channelHidden', { channelId });
   }
 
   /*****************************************************************************
@@ -270,5 +270,14 @@ export class ChatsGateway {
       .in(`chatRooms-${channelId}`)
       .except(`chatRooms-${channelId}-active`)
       .emit('messageArrived', { channelId });
+  }
+
+  /**
+   * @description 채널이 삭제 되었을 때, chats-UI 를 보고 있는 유저에게 알림
+   *
+   * @param channelId 삭제된 채널
+   */
+  private emitChannelDeleted(channelId: ChannelId) {
+    this.server.in('chats').emit('channelDeleted', { channelId });
   }
 }

--- a/backend/src/chats/chats.service.spec.ts
+++ b/backend/src/chats/chats.service.spec.ts
@@ -1090,12 +1090,12 @@ describe('ChatsService', () => {
   });
 
   describe('updateChannel', () => {
-    let channelCreatedSpy: jest.SpyInstance;
+    let channelShown: jest.SpyInstance;
     let channelHiddenSpy: jest.SpyInstance;
     let channelUpdatedSpy: jest.SpyInstance;
     beforeEach(() => {
-      channelCreatedSpy = jest
-        .spyOn(chatsGateway, 'emitChannelCreated')
+      channelShown = jest
+        .spyOn(chatsGateway, 'emitChannelShown')
         .mockImplementation(() => undefined);
       channelHiddenSpy = jest
         .spyOn(chatsGateway, 'emitChannelHidden')
@@ -1262,10 +1262,11 @@ describe('ChatsService', () => {
         0,
         updatedChannelData.accessMode,
       );
-      expect(channelCreatedSpy).toBeCalledWith(
+      expect(channelShown).toBeCalledWith(
         channelId,
         channel.name,
         updatedChannelData.accessMode,
+        channelStorage.getChannel(channelId).userRoleMap.size,
       );
     });
 
@@ -1290,11 +1291,11 @@ describe('ChatsService', () => {
         0,
         updatedChannelData.accessMode,
       );
-      console.log('here is test');
-      expect(channelCreatedSpy).toBeCalledWith(
+      expect(channelShown).toBeCalledWith(
         channelId,
         channel.name,
         updatedChannelData.accessMode,
+        channelStorage.getChannel(channelId).userRoleMap.size,
       );
     });
 

--- a/backend/src/chats/chats.service.spec.ts
+++ b/backend/src/chats/chats.service.spec.ts
@@ -13,7 +13,7 @@ import { Channels } from '../entity/channels.entity';
 import { ChatsGateway } from './chats.gateway';
 import { ChatsModule } from './chats.module';
 import { ChatsService } from './chats.service';
-import { CreateChannelDto } from './dto/chats.dto';
+import { CreateChannelDto, UpdateChannelDto } from './dto/chats.dto';
 import { Messages } from '../entity/messages.entity';
 import {
   TYPEORM_SHARED_CONFIG,
@@ -30,7 +30,7 @@ import {
   generateMessages,
   generateUsers,
 } from '../../test/util/generate-mock-data';
-import { ValidateNewChannelPipe } from './pipe/validate-new-channel.pipe';
+import { ValidateChannelInfoPipe } from './pipe/validate-channel-info.pipe';
 
 const TEST_DB = 'test_db_chat_service';
 const ENTITIES = [BannedMembers, ChannelMembers, Channels, Messages, Users];
@@ -52,7 +52,7 @@ describe('ChatsService', () => {
     const dataSources = await createDataSources(TEST_DB, ENTITIES);
     initDataSource = dataSources.initDataSource;
     dataSource = dataSources.dataSource;
-    usersEntities = generateUsers(10);
+    usersEntities = generateUsers(50);
     channelsEntities = generateChannels(usersEntities);
     channelsEntities
       .filter((_, index) => index & 1)
@@ -260,9 +260,9 @@ describe('ChatsService', () => {
         password: '1q2w3e4r',
         accessMode: 'protected',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       expect(channelStorage.getUser(userId).has(newChannelId)).toBeTruthy();
       expect(channelStorage.getUserRole(newChannelId, userId)).toBe('owner');
@@ -293,7 +293,7 @@ describe('ChatsService', () => {
       };
       expect(
         async () =>
-          await new ValidateNewChannelPipe().transform(newChannelData),
+          await new ValidateChannelInfoPipe().transform(newChannelData),
       ).rejects.toThrow(BadRequestException);
     });
   });
@@ -358,9 +358,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'public',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[1].userId;
       await service.joinChannel(newChannelId, anotherUserId, false);
@@ -381,9 +381,9 @@ describe('ChatsService', () => {
         password: '1q2w3e4r',
         accessMode: 'protected',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[1].userId;
       await service.joinChannel(newChannelId, anotherUserId, false, '1q2w3e4r');
@@ -404,9 +404,9 @@ describe('ChatsService', () => {
         password: 'trickyPassword',
         accessMode: 'protected',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[1].userId;
       expect(async () =>
@@ -424,9 +424,9 @@ describe('ChatsService', () => {
         password: 'password',
         accessMode: 'protected',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[1].userId;
       await service.joinChannel(newChannelId, anotherUserId, true);
@@ -446,9 +446,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[1].userId;
       expect(async () =>
@@ -462,9 +462,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[1].userId;
       await service.joinChannel(newChannelId, anotherUserId, true);
@@ -502,9 +502,9 @@ describe('ChatsService', () => {
         password: 'password',
         accessMode: 'protected',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[1].userId;
       await service.joinChannel(newChannelId, anotherUserId, true);
@@ -527,9 +527,9 @@ describe('ChatsService', () => {
         password: 'trickyPassword',
         accessMode: 'protected',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[1].userId;
       await service.joinChannel(newChannelId, anotherUserId, true);
@@ -549,9 +549,9 @@ describe('ChatsService', () => {
         password: 'trickyPassword',
         accessMode: 'protected',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[1].userId;
       await service.joinChannel(newChannelId, anotherUserId, true);
@@ -680,9 +680,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(userId, newChannelData);
       const anotherUserId = usersEntities[2].userId;
       activityManager.setActivity(userId, `chatRooms-${newChannelId}`);
@@ -723,9 +723,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const anotherUserId = usersEntities[2].userId;
 
@@ -764,9 +764,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const memberId = usersEntities[2].userId;
       const adminId = usersEntities[3].userId;
@@ -797,9 +797,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const memberId = usersEntities[2].userId;
       const adminId = usersEntities[3].userId;
@@ -840,9 +840,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const anotherUserId = usersEntities[2].userId;
       await service.joinChannel(newChannelId, anotherUserId, true);
@@ -862,9 +862,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const anotherUserId = usersEntities[2].userId;
       await service.joinChannel(newChannelId, anotherUserId, true);
@@ -892,9 +892,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const memberId = usersEntities[2].userId;
       const adminId = usersEntities[3].userId;
@@ -939,9 +939,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const memberId = usersEntities[2].userId;
       const adminId = usersEntities[3].userId;
@@ -973,9 +973,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const memberId = usersEntities[2].userId;
       const adminId = usersEntities[3].userId;
@@ -1015,9 +1015,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const memberId = usersEntities[2].userId;
       const adminId = usersEntities[3].userId;
@@ -1041,9 +1041,9 @@ describe('ChatsService', () => {
         channelName: 'newChannel',
         accessMode: 'private',
       };
-      newChannelData = await new ValidateNewChannelPipe().transform(
+      newChannelData = (await new ValidateChannelInfoPipe().transform(
         newChannelData,
-      );
+      )) as CreateChannelDto;
       const newChannelId = await service.createChannel(ownerId, newChannelData);
       const memberId = usersEntities[2].userId;
       const adminId = usersEntities[3].userId;
@@ -1086,6 +1086,238 @@ describe('ChatsService', () => {
             ownerId,
           ]),
       ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('updateChannel', () => {
+    let channelCreatedSpy: jest.SpyInstance;
+    let channelDeletedSpy: jest.SpyInstance;
+    let channelUpdatedSpy: jest.SpyInstance;
+    beforeEach(() => {
+      channelCreatedSpy = jest
+        .spyOn(chatsGateway, 'emitChannelCreated')
+        .mockImplementation(() => undefined);
+      channelDeletedSpy = jest
+        .spyOn(chatsGateway, 'emitChannelDeleted')
+        .mockImplementation(() => undefined);
+      channelUpdatedSpy = jest
+        .spyOn(chatsGateway, 'emitChannelUpdated')
+        .mockImplementation(() => undefined);
+      const joinChannelSpy = jest
+        .spyOn(service, 'joinChannel')
+        .mockImplementation(() => undefined);
+    });
+
+    it('should update channel (public -> public)', async () => {
+      const channel = channelsEntities.find((c) => c.accessMode === 'public');
+      if (!channel) {
+        console.log('SKIP CHANNEL UPDATE TEST !!');
+      }
+      const channelId = channel.channelId;
+      const updatedChannelData: UpdateChannelDto = {
+        accessMode: 'public',
+      };
+      await service.updateChannel(channelId, updatedChannelData);
+      expect(channelStorage.getChannel(channelId).accessMode).toBe(
+        updatedChannelData.accessMode,
+      );
+      expect(channelUpdatedSpy).toBeCalledWith(
+        channelId,
+        0,
+        updatedChannelData.accessMode,
+      );
+    });
+
+    it('should update channel (public -> protected)', async () => {
+      const channel = channelsEntities.filter(
+        (c) => c.accessMode === 'public',
+      )[1];
+      if (!channel) {
+        console.log('SKIP CHANNEL UPDATE TEST !!');
+      }
+      const channelId = channel.channelId;
+      const updatedChannelData: UpdateChannelDto = {
+        accessMode: 'protected',
+        password: '123456abcd',
+      };
+      await service.updateChannel(channelId, updatedChannelData);
+      expect(channelStorage.getChannel(channelId).accessMode).toBe(
+        updatedChannelData.accessMode,
+      );
+      expect(channelUpdatedSpy).toBeCalledWith(
+        channelId,
+        0,
+        updatedChannelData.accessMode,
+      );
+    });
+
+    it('should update channel (public -> private)', async () => {
+      const channel = channelsEntities.filter(
+        (c) => c.accessMode === 'public',
+      )[2];
+      if (!channel) {
+        console.log('SKIP CHANNEL UPDATE TEST !!');
+      }
+      const channelId = channel.channelId;
+      const updatedChannelData: UpdateChannelDto = {
+        accessMode: 'private',
+      };
+      await service.updateChannel(channelId, updatedChannelData);
+      expect(channelStorage.getChannel(channelId).accessMode).toBe(
+        updatedChannelData.accessMode,
+      );
+      expect(channelUpdatedSpy).toBeCalledWith(
+        channelId,
+        0,
+        updatedChannelData.accessMode,
+      );
+      expect(channelDeletedSpy).toBeCalledWith(channelId);
+    });
+
+    it('should update channel (protected -> public)', async () => {
+      const channel = channelsEntities.filter(
+        (c) => c.accessMode === 'protected',
+      )[0];
+      if (!channel) {
+        console.log('SKIP CHANNEL UPDATE TEST !!');
+      }
+      const channelId = channel.channelId;
+      const updatedChannelData: UpdateChannelDto = {
+        accessMode: 'public',
+      };
+      await service.updateChannel(channelId, updatedChannelData);
+      expect(channelStorage.getChannel(channelId).accessMode).toBe(
+        updatedChannelData.accessMode,
+      );
+      expect(channelUpdatedSpy).toBeCalledWith(
+        channelId,
+        0,
+        updatedChannelData.accessMode,
+      );
+    });
+
+    it('should update channel (protected -> protected)', async () => {
+      const channel = channelsEntities.filter(
+        (c) => c.accessMode === 'protected',
+      )[1];
+      if (!channel) {
+        console.log('SKIP CHANNEL UPDATE TEST !!');
+      }
+      const channelId = channel.channelId;
+      const updatedChannelData: UpdateChannelDto = {
+        accessMode: 'protected',
+        password: '123456abcd',
+      };
+      await service.updateChannel(channelId, updatedChannelData);
+      expect(channelStorage.getChannel(channelId).accessMode).toBe(
+        updatedChannelData.accessMode,
+      );
+      expect(channelUpdatedSpy).toBeCalledWith(
+        channelId,
+        0,
+        updatedChannelData.accessMode,
+      );
+    });
+
+    it('should update channel (protected -> private)', async () => {
+      const channel = channelsEntities.filter(
+        (c) => c.accessMode === 'protected',
+      )[2];
+      if (!channel) {
+        console.log('SKIP CHANNEL UPDATE TEST !!');
+      }
+      const channelId = channel.channelId;
+      const updatedChannelData: UpdateChannelDto = {
+        accessMode: 'private',
+      };
+      await service.updateChannel(channelId, updatedChannelData);
+      expect(channelStorage.getChannel(channelId).accessMode).toBe(
+        updatedChannelData.accessMode,
+      );
+      expect(channelUpdatedSpy).toBeCalledWith(
+        channelId,
+        0,
+        updatedChannelData.accessMode,
+      );
+      expect(channelDeletedSpy).toBeCalledWith(channelId);
+    });
+
+    it('should update channel (private -> public)', async () => {
+      const channel = channelsEntities.filter(
+        (c) => c.accessMode === 'private',
+      )[0];
+      if (!channel) {
+        console.log('SKIP CHANNEL UPDATE TEST !!');
+      }
+      const channelId = channel.channelId;
+      const updatedChannelData: UpdateChannelDto = {
+        accessMode: 'public',
+      };
+      await service.updateChannel(channelId, updatedChannelData);
+      expect(channelStorage.getChannel(channelId).accessMode).toBe(
+        updatedChannelData.accessMode,
+      );
+      expect(channelUpdatedSpy).toBeCalledWith(
+        channelId,
+        0,
+        updatedChannelData.accessMode,
+      );
+      expect(channelCreatedSpy).toBeCalledWith(
+        channelId,
+        channel.name,
+        updatedChannelData.accessMode,
+      );
+    });
+
+    it('should update channel (private -> protected)', async () => {
+      const channel = channelsEntities.filter(
+        (c) => c.accessMode === 'private',
+      )[1];
+      if (!channel) {
+        console.log('SKIP CHANNEL UPDATE TEST !!');
+      }
+      const channelId = channel.channelId;
+      const updatedChannelData: UpdateChannelDto = {
+        accessMode: 'protected',
+        password: '123456abcd',
+      };
+      await service.updateChannel(channelId, updatedChannelData);
+      expect(channelStorage.getChannel(channelId).accessMode).toBe(
+        updatedChannelData.accessMode,
+      );
+      expect(channelUpdatedSpy).toBeCalledWith(
+        channelId,
+        0,
+        updatedChannelData.accessMode,
+      );
+      console.log('here is test');
+      expect(channelCreatedSpy).toBeCalledWith(
+        channelId,
+        channel.name,
+        updatedChannelData.accessMode,
+      );
+    });
+
+    it('should update channel (private -> private)', async () => {
+      const channel = channelsEntities.filter(
+        (c) => c.accessMode === 'private',
+      )[2];
+      if (!channel) {
+        console.log('SKIP CHANNEL UPDATE TEST !!');
+      }
+      const channelId = channel.channelId;
+      const updatedChannelData: UpdateChannelDto = {
+        accessMode: 'private',
+      };
+      await service.updateChannel(channelId, updatedChannelData);
+      expect(channelStorage.getChannel(channelId).accessMode).toBe(
+        updatedChannelData.accessMode,
+      );
+      expect(channelUpdatedSpy).toBeCalledWith(
+        channelId,
+        0,
+        updatedChannelData.accessMode,
+      );
     });
   });
 });

--- a/backend/src/chats/chats.service.spec.ts
+++ b/backend/src/chats/chats.service.spec.ts
@@ -1091,14 +1091,14 @@ describe('ChatsService', () => {
 
   describe('updateChannel', () => {
     let channelCreatedSpy: jest.SpyInstance;
-    let channelDeletedSpy: jest.SpyInstance;
+    let channelHiddenSpy: jest.SpyInstance;
     let channelUpdatedSpy: jest.SpyInstance;
     beforeEach(() => {
       channelCreatedSpy = jest
         .spyOn(chatsGateway, 'emitChannelCreated')
         .mockImplementation(() => undefined);
-      channelDeletedSpy = jest
-        .spyOn(chatsGateway, 'emitChannelDeleted')
+      channelHiddenSpy = jest
+        .spyOn(chatsGateway, 'emitChannelHidden')
         .mockImplementation(() => undefined);
       channelUpdatedSpy = jest
         .spyOn(chatsGateway, 'emitChannelUpdated')
@@ -1171,7 +1171,7 @@ describe('ChatsService', () => {
         0,
         updatedChannelData.accessMode,
       );
-      expect(channelDeletedSpy).toBeCalledWith(channelId);
+      expect(channelHiddenSpy).toBeCalledWith(channelId);
     });
 
     it('should update channel (protected -> public)', async () => {
@@ -1239,7 +1239,7 @@ describe('ChatsService', () => {
         0,
         updatedChannelData.accessMode,
       );
-      expect(channelDeletedSpy).toBeCalledWith(channelId);
+      expect(channelHiddenSpy).toBeCalledWith(channelId);
     });
 
     it('should update channel (private -> public)', async () => {

--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -7,13 +7,17 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { DateTime } from 'luxon';
+import { EntityNotFoundError, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
 import { compare } from 'bcrypt';
 
 import { AccessMode, Channels } from '../entity/channels.entity';
 import { ActivityManager } from '../user-status/activity.manager';
-import { AllChannelsDto, CreateChannelDto } from './dto/chats.dto';
+import {
+  AllChannelsDto,
+  CreateChannelDto,
+  UpdateChannelDto,
+} from './dto/chats.dto';
 import { ChannelStorage } from '../user-status/channel.storage';
 import { ChannelId, UserChannelStatus, UserId, UserRole } from '../util/type';
 import { ChatsGateway } from './chats.gateway';
@@ -90,6 +94,36 @@ export class ChatsService {
     }
     this.chatsGateway.joinChannelRoom(channelId, userId);
     return channelId;
+  }
+
+  async updateChannel(channelId: ChannelId, channel: UpdateChannelDto) {
+    const { accessMode, password } = channel;
+    const prevAccessMode = this.channelStorage.getChannel(channelId).accessMode;
+
+    await this.channelStorage.updateChannel(
+      channelId,
+      accessMode as AccessMode,
+      password,
+    );
+    if (prevAccessMode === 'private' && accessMode !== 'private') {
+      try {
+        const name = (
+          await this.channelsRepository.findOneOrFail({
+            where: { channelId },
+            select: ['name'],
+          })
+        ).name;
+        this.chatsGateway.emitChannelCreated(channelId, name, accessMode);
+      } catch (e) {
+        this.logger.error(e);
+        throw e instanceof EntityNotFoundError
+          ? new NotFoundException('Channel not found')
+          : new InternalServerErrorException('Failed to get channel name');
+      }
+    } else if (prevAccessMode !== 'private' && accessMode === 'private') {
+      this.chatsGateway.emitChannelDeleted(channelId);
+    }
+    this.chatsGateway.emitChannelUpdated(channelId, 0, accessMode);
   }
 
   /*****************************************************************************

--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -121,7 +121,7 @@ export class ChatsService {
           : new InternalServerErrorException('Failed to get channel name');
       }
     } else if (prevAccessMode !== 'private' && accessMode === 'private') {
-      this.chatsGateway.emitChannelDeleted(channelId);
+      this.chatsGateway.emitChannelHidden(channelId);
     }
     this.chatsGateway.emitChannelUpdated(channelId, 0, accessMode);
   }

--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -256,7 +256,7 @@ export class ChatsService {
   async executeCommand(
     channelId: ChannelId,
     senderId: UserId,
-    command: [string, number, string],
+    command: [string, number, string?],
   ) {
     const [kind, targetId, arg] = command;
     if (this.channelStorage.getUserRole(channelId, targetId) === null) {
@@ -275,7 +275,9 @@ export class ChatsService {
       await this.channelStorage.updateMuteStatus(channelId, targetId, minutes);
       return this.chatsGateway.emitMuted(targetId, channelId, minutes);
     } else {
-      const minutes = now.plus({ minutes: Number(arg) });
+      const minutes = arg
+        ? now.plus({ minutes: Number(arg) })
+        : now.plus({ years: 142 });
       await this.channelStorage.banUser(channelId, targetId, minutes);
       this.chatsGateway.emitMemberLeft(channelId, targetId, false);
       return this.chatsGateway.emitBanned(channelId, targetId);

--- a/backend/src/chats/dto/chats.dto.ts
+++ b/backend/src/chats/dto/chats.dto.ts
@@ -51,6 +51,17 @@ export class CreateChannelDto {
   accessMode: 'public' | 'protected' | 'private';
 }
 
+export class UpdateChannelDto {
+  @IsAlphanumeric()
+  @Length(8, 16)
+  @IsOptional()
+  password?: string;
+
+  @IsString()
+  @Matches(/^(public|protected|private)$/)
+  accessMode: 'public' | 'protected' | 'private';
+}
+
 export class MessageDto {
   @IsString()
   @Length(1, 4096)

--- a/backend/src/chats/guard/channel-owner.guard.ts
+++ b/backend/src/chats/guard/channel-owner.guard.ts
@@ -1,0 +1,27 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+
+import { ChannelStorage } from '../../user-status/channel.storage';
+import { VerifiedRequest } from '../../util/type';
+
+@Injectable()
+export class ChannelOwnerGuard implements CanActivate {
+  constructor(private readonly channelStorage: ChannelStorage) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<VerifiedRequest>();
+    const { channelId } = req.params;
+    const safeChannelId = Math.floor(Number(channelId));
+    if (
+      this.channelStorage.getUserRole(safeChannelId, req.user.userId) !==
+      'owner'
+    ) {
+      throw new ForbiddenException(`This user is not an owner of the channel`);
+    }
+    return true;
+  }
+}

--- a/backend/src/chats/pipe/message-transform.pipe.ts
+++ b/backend/src/chats/pipe/message-transform.pipe.ts
@@ -13,7 +13,7 @@ import { MessageDto } from '../dto/chats.dto';
 import { Users } from '../../entity/users.entity';
 
 const COMMAND_REGEX =
-  /^\/((role [a-z|A-Z]{1,16} (admin|member))|((ban|mute) [a-z|A-Z]{1,16} \d{1,4}))$/;
+  /^\/((role [a-z|A-Z]{1,16} (admin|member))|((ban|mute) [a-z|A-Z]{1,16} \d{1,4}))|((kick) [a-z|A-Z]{1,16})$/;
 
 @Injectable()
 export class MessageTransformPipe implements PipeTransform {

--- a/backend/src/chats/pipe/validate-channel-info.pipe.ts
+++ b/backend/src/chats/pipe/validate-channel-info.pipe.ts
@@ -1,17 +1,17 @@
 import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
 import { hash } from 'bcrypt';
 
-import { CreateChannelDto } from '../dto/chats.dto';
+import { CreateChannelDto, UpdateChannelDto } from '../dto/chats.dto';
 
 @Injectable()
-export class ValidateNewChannelPipe implements PipeTransform {
-  async transform(value: CreateChannelDto) {
+export class ValidateChannelInfoPipe implements PipeTransform {
+  async transform(value: CreateChannelDto | UpdateChannelDto) {
     const password = this.validate(value);
     value.password = password === undefined ? null : await hash(password, 10);
     return value;
   }
 
-  private validate(value: CreateChannelDto) {
+  private validate(value: CreateChannelDto | UpdateChannelDto) {
     const { accessMode, password } = value;
     if (accessMode === 'protected' && !password) {
       throw new BadRequestException(

--- a/backend/src/user-status/channel.storage.ts
+++ b/backend/src/user-status/channel.storage.ts
@@ -250,6 +250,30 @@ export class ChannelStorage implements OnModuleInit {
   }
 
   /**
+   * @description 채팅방 정보 수정
+   *
+   * @param channelId 채팅방 id
+   * @param accessMode 채팅방 접근 권한
+   * @param password 채팅방 비밀번호
+   */
+  async updateChannel(
+    channelId: ChannelId,
+    accessMode: AccessMode,
+    password: string | null = null,
+  ) {
+    try {
+      this.channelsRepository.update(channelId, {
+        accessMode,
+        password,
+      });
+    } catch (e) {
+      this.logger.error(e);
+      throw new InternalServerErrorException(`Failed to update channel`);
+    }
+    this.getChannel(channelId).accessMode = accessMode;
+  }
+
+  /**
    * @description 채팅방에 유저 추가
    *
    * @param channelId 채팅방 id

--- a/backend/test/chats-gateway.e2e-spec.ts
+++ b/backend/test/chats-gateway.e2e-spec.ts
@@ -208,7 +208,11 @@ describe('ChatsGateway (e2e)', () => {
     const channelUpdatedMsg = await new Promise((resolve) =>
       clientSockets[2].on('channelUpdated', (data) => resolve(data)),
     );
-    expect(channelUpdatedMsg).toEqual({ channelId: 1, memberCountDiff: 1 });
+    expect(channelUpdatedMsg).toEqual({
+      channelId: 1,
+      memberCountDiff: 1,
+      accessMode: null,
+    });
   });
 
   it('should send newMessage and messageArrived events to appropriate users', async () => {


### PR DESCRIPTION
## 개요
- #222 완료
## 작업 사항
- 채팅방에서 `/kick nickname` message 가 올 경우 해당 유저 영구 벤
  - 142 년 BAN 으로 구현해뒀습니다.
- 채팅방 정보 수정하는 `PATCH /chats/:channelId` 를 구현했습니다.
  - API 구현을 미루려고 했는데, 채팅방 UI 에서 수정 버튼을 누르면 모달창(방만들기 모달창을 조금만 수정하면 됩니다.) 을 띄워주는 방식을 사용하여 요청을 보내면 적당할 것 같습니다. 채팅방 UI 가 어느정도 구현하면 제가 초대 버튼과 함께 만들어 보겠습니다.
- 채팅방 정보 수정에 따른 WebSocket event 전송
  - 이미 렌더링 된 방 정보 수정은 `updateChannel` 이벤트에 데이터를 추가하는 형식으로 구현하였습니다.
  - public/protected -> private || private -> public/protected 로 변경되는 상황에선 Chats UI 에서 방을 새로 그려줘야 하기 때문에 이벤트를 추가로 emit 해줍니다.

---
## 추가내용
- AccessMode 변경에 따른 방 정보 렌더링 여부를 기존 channelCreated / channelDeleted 이벤트를 재활용하여 적용할 예정이였는데, 불가능하다는 것을 깨닫고 channelShown / channelHidden 이벤트로 분리했습니다

close #222