### PR TITLE
:bug: fix : HTTP 와 Socket 에서 전달하는 message 타입이 다른 문제 해결

### DIFF
--- a/backend/src/chats/chats.gateway.ts
+++ b/backend/src/chats/chats.gateway.ts
@@ -172,20 +172,20 @@ export class ChatsGateway {
    * @param userId 메시지를 보낸 유저의 id
    * @param channelId 메시지를 보낸 채팅방의 id
    * @param messageId 메시지의 id
-   * @param content 메시지 내용
+   * @param contents 메시지 내용
    * @param sentAt 메시지 작성 시간
    */
   emitNewMessage(
     channelId: ChannelId,
     senderId: UserId,
     messageId: MessageId,
-    content: string,
+    contents: string,
     createdAt: DateTime,
   ) {
     this.server.in(`chatRooms-${channelId}-active`).emit('newMessage', {
       senderId,
       messageId,
-      content,
+      contents,
       createdAt: createdAt.toMillis(),
     });
     this.emitMessageArrived(channelId);

--- a/backend/src/chats/chats.service.spec.ts
+++ b/backend/src/chats/chats.service.spec.ts
@@ -351,6 +351,11 @@ describe('ChatsService', () => {
       jest
         .spyOn(chatsGateway, 'joinChannelRoom')
         .mockImplementation(() => undefined);
+      jest
+        .spyOn(chatsGateway, 'getRoomMembers')
+        .mockImplementation((chatRoom: string) =>
+          new Set<string>().add(chatRoom),
+        );
     });
     it('should join user to the public channel', async () => {
       const userId = usersEntities[0].userId;
@@ -494,6 +499,11 @@ describe('ChatsService', () => {
       jest
         .spyOn(chatsGateway, 'joinChannelRoom')
         .mockImplementation(() => undefined);
+      jest
+        .spyOn(chatsGateway, 'getRoomMembers')
+        .mockImplementation((chatRoom: string) =>
+          new Set<string>().add(chatRoom),
+        );
     });
     it('should leave channel (not owner)', async () => {
       const userId = usersEntities[0].userId;
@@ -682,6 +692,12 @@ describe('ChatsService', () => {
       jest
         .spyOn(chatsGateway, 'joinChannelRoom')
         .mockImplementation(() => undefined);
+
+      jest
+        .spyOn(chatsGateway, 'getRoomMembers')
+        .mockImplementation((chatRoom: string) =>
+          new Set<string>().add(chatRoom),
+        );
     });
 
     it('should create message and then notify new message arrived', async () => {

--- a/backend/src/chats/dto/chats-gateway.dto.ts
+++ b/backend/src/chats/dto/chats-gateway.dto.ts
@@ -9,8 +9,8 @@ export interface MemberJoinedMessage {
 export interface NewMessage {
   senderId: UserId;
   messageId: MessageId;
-  content: string;
   createdAt: DateTime;
+  contents: string;
 }
 
 export interface LeftMessage {

--- a/backend/test/chats-gateway.e2e-spec.ts
+++ b/backend/test/chats-gateway.e2e-spec.ts
@@ -232,15 +232,15 @@ describe('ChatsGateway (e2e)', () => {
     const sentMsg: NewMessage = {
       senderId: users[0].userId,
       messageId: 4242,
-      content: 'nice to meet you',
       createdAt: DateTime.now(),
+      contents: 'nice to meet you',
     };
     await new Promise((resolve) => setTimeout(() => resolve('done'), 1000));
     chatsGateway.emitNewMessage(
       channel.channelId,
       sentMsg.senderId,
       4242,
-      sentMsg.content,
+      sentMsg.contents,
       sentMsg.createdAt,
     );
     const recvMsg = await Promise.all([


### PR DESCRIPTION
## 개요
- 메시지의 내용을 `GET /chats/:channelId/message` 에선 contents, `newMessage` 에선 content 로 보내주던 문제를 해결하였습니다.
