### PR TITLE
:bug: fix : 채팅방에서 명령어 사용시 발생하는 버그 fix

### DIFF
--- a/backend/src/chats/chats.gateway.ts
+++ b/backend/src/chats/chats.gateway.ts
@@ -245,7 +245,7 @@ export class ChatsGateway {
    */
   emitMuted(channelId: ChannelId, mutedMember: UserId, muteEndAt: DateTime) {
     const socketId = this.userSocketStorage.clients.get(mutedMember);
-    if (socketId) {
+    if (this.getRoomMembers(`chatRooms-${channelId}-active`)?.has(socketId)) {
       this.server.in(socketId).emit('muted', {
         mutedMember,
         channelId,
@@ -280,11 +280,12 @@ export class ChatsGateway {
     }
   }
 
-  /*****************************************************************************
-   *                                                                           *
-   * NOTE : test Only (maybe)                                                  *
-   *                                                                           *
-   ****************************************************************************/
+  /**
+   * @description socket Room 에 있는 모든 멤버의 socket id 를 반환
+   *
+   * @param chatRoom socket Room 의 이름
+   * @returns socket Room 에 있는 모든 멤버의 socket id
+   */
   getRoomMembers(chatRoom: string) {
     return this.server.sockets.adapter.rooms.get(chatRoom);
   }

--- a/backend/src/chats/chats.service.spec.ts
+++ b/backend/src/chats/chats.service.spec.ts
@@ -766,8 +766,8 @@ describe('ChatsService', () => {
         'admin',
       );
       expect(roleChangedSpy).toBeCalledWith(
-        anotherUserId,
         newChannelId,
+        anotherUserId,
         'admin',
       );
       await service.executeCommand(newChannelId, ownerId, [
@@ -779,8 +779,8 @@ describe('ChatsService', () => {
         'member',
       );
       expect(roleChangedSpy).toBeCalledWith(
-        anotherUserId,
         newChannelId,
+        anotherUserId,
         'member',
       );
     });
@@ -807,7 +807,7 @@ describe('ChatsService', () => {
         'admin',
       ]);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
-      expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
+      expect(roleChangedSpy).toBeCalledWith(newChannelId, adminId, 'admin');
 
       await service.executeCommand(newChannelId, adminId, [
         'role',
@@ -815,7 +815,7 @@ describe('ChatsService', () => {
         'admin',
       ]);
       expect(channelStorage.getUserRole(newChannelId, memberId)).toBe('admin');
-      expect(roleChangedSpy).toBeCalledWith(memberId, newChannelId, 'admin');
+      expect(roleChangedSpy).toBeCalledWith(newChannelId, memberId, 'admin');
     });
 
     it('should not execute role command (executor : member)', async () => {
@@ -840,7 +840,7 @@ describe('ChatsService', () => {
         'admin',
       ]);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
-      expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
+      expect(roleChangedSpy).toBeCalledWith(newChannelId, adminId, 'admin');
 
       expect(
         async () =>
@@ -935,7 +935,7 @@ describe('ChatsService', () => {
         'admin',
       ]);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
-      expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
+      expect(roleChangedSpy).toBeCalledWith(newChannelId, adminId, 'admin');
 
       await service.executeCommand(newChannelId, ownerId, [
         'mute',
@@ -954,8 +954,8 @@ describe('ChatsService', () => {
         ),
       ).toBe(-5);
       expect(mutedSpy).toBeCalledWith(
-        memberId,
         newChannelId,
+        memberId,
         expect.any(DateTime),
       );
     });
@@ -982,7 +982,7 @@ describe('ChatsService', () => {
         'admin',
       ]);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
-      expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
+      expect(roleChangedSpy).toBeCalledWith(newChannelId, adminId, 'admin');
 
       expect(
         async () =>
@@ -1016,7 +1016,7 @@ describe('ChatsService', () => {
         'admin',
       ]);
       expect(channelStorage.getUserRole(newChannelId, adminId)).toBe('admin');
-      expect(roleChangedSpy).toBeCalledWith(adminId, newChannelId, 'admin');
+      expect(roleChangedSpy).toBeCalledWith(newChannelId, adminId, 'admin');
 
       await service.executeCommand(newChannelId, adminId, [
         'ban',

--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -455,7 +455,8 @@ export class ChatsService {
       !senderRole ||
       !targetRole ||
       senderRole === 'member' ||
-      userRoles[senderRole] <= userRoles[targetRole]
+      userRoles[senderRole] <= userRoles[targetRole] ||
+      this.userRelationshipStorage.isBlockedDm(channelId) !== undefined
     ) {
       throw new ForbiddenException(`You don't have permission to do this`);
     }

--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -324,11 +324,11 @@ export class ChatsService {
     if (kind === 'role') {
       const role = arg as 'admin' | 'member';
       await this.channelStorage.updateUserRole(channelId, targetId, role);
-      return this.chatsGateway.emitRoleChanged(targetId, channelId, role);
+      return this.chatsGateway.emitRoleChanged(channelId, targetId, role);
     } else if (kind === 'mute') {
       const minutes = now.plus({ minutes: Number(arg) });
       await this.channelStorage.updateMuteStatus(channelId, targetId, minutes);
-      return this.chatsGateway.emitMuted(targetId, channelId, minutes);
+      return this.chatsGateway.emitMuted(channelId, targetId, minutes);
     } else {
       const minutes = arg
         ? now.plus({ minutes: Number(arg) })

--- a/backend/test/chats.e2e-spec.ts
+++ b/backend/test/chats.e2e-spec.ts
@@ -11,6 +11,7 @@ import { BlockedUsers } from '../src/entity/blocked-users.entity';
 import { ChannelMembers } from '../src/entity/channel-members.entity';
 import { ChannelStorage } from '../src/user-status/channel.storage';
 import { Channels } from '../src/entity/channels.entity';
+import { DateTime } from 'luxon';
 import { Friends } from '../src/entity/friends.entity';
 import { Messages } from '../src/entity/messages.entity';
 import { UserRelationshipStorage } from '../src/user-status/user-relationship.storage';
@@ -921,10 +922,12 @@ describe('UserController (e2e)', () => {
     });
 
     it('POST /chats/:channelId/message (valid DTO), muted member', async () => {
-      const channel = channelsEntities.find((c) => c.dmPeerId !== null);
+      const channel = channelsEntities.find((c) => c.dmPeerId === null);
       const member = channelMembersEntities.find(
         (c) =>
-          c.channelId === channel.channelId && c.memberId !== channel.ownerId,
+          c.channelId === channel.channelId &&
+          c.memberId !== channel.ownerId &&
+          c.muteEndAt < DateTime.now(),
       );
       const memberNickname = usersEntities.find(
         (u) => u.userId === member.memberId,


### PR DESCRIPTION
## 개요
- #259 해결
- #258 해결
## 작업 사항
- DM 방에서 명령어 사용 시 403 응답
- mute 및 role change Event 에 memberId, channelId 반대로 들어가 있던 문제 해결

close #258
close #259 
