### PR TITLE
✨ feat : 일반 게임 초대 거절 API

### DIFF
--- a/backend/src/game/guard/existing-game.guard.ts
+++ b/backend/src/game/guard/existing-game.guard.ts
@@ -1,0 +1,36 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { GameRequest } from '../../util/type';
+import { GameStorage } from '../game.storage';
+
+@Injectable()
+export class ExistingGameGuard implements CanActivate {
+  constructor(private readonly gameStorage: GameStorage) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<GameRequest>();
+    const {
+      user: { userId },
+      params: { gameId },
+    } = req;
+    if (!gameId.match(/^[0-9A-Za-z_-]{21}$/)) {
+      throw new BadRequestException(
+        `The game(${gameId}) requested by ${userId} is not valid`,
+      );
+    }
+    const gameInfo = this.gameStorage.getGame(gameId);
+    if (gameInfo === undefined) {
+      throw new NotFoundException(
+        `The game(${gameId}) requested by ${userId} does not exist`,
+      );
+    }
+    req.gameInfo = gameInfo;
+    return true;
+  }
+}

--- a/backend/src/game/guard/is-player.guard.ts
+++ b/backend/src/game/guard/is-player.guard.ts
@@ -1,0 +1,28 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+
+import { GameRequest } from '../../util/type';
+import { GameStorage } from '../game.storage';
+
+@Injectable()
+export class IsPlayerGuard implements CanActivate {
+  constructor(private readonly gameStorage: GameStorage) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<GameRequest>();
+    const {
+      user: { userId },
+      params: { gameId },
+    } = req;
+    if (this.gameStorage.players.get(userId) !== gameId) {
+      throw new ForbiddenException(
+        `The requester(${userId}) is not a participant of the game`,
+      );
+    }
+    return true;
+  }
+}

--- a/backend/src/game/guard/ladder-restriction.guard.ts
+++ b/backend/src/game/guard/ladder-restriction.guard.ts
@@ -1,0 +1,25 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+} from '@nestjs/common';
+
+import { GameRequest } from '../../util/type';
+
+@Injectable()
+export class LadderRestrictionGuard implements CanActivate {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest<GameRequest>();
+    const {
+      user: { userId },
+      gameInfo: { isRank },
+    } = req;
+    if (isRank) {
+      throw new BadRequestException(
+        `The requester(${userId}) cannot modify a ladder game`,
+      );
+    }
+    return true;
+  }
+}

--- a/backend/src/util/type.ts
+++ b/backend/src/util/type.ts
@@ -115,6 +115,10 @@ export interface VerifiedRequest extends Request {
   user: { userId: UserId };
 }
 
+export interface GameRequest extends VerifiedRequest {
+  gameInfo: GameInfo;
+}
+
 export interface RelationshipRequest extends VerifiedRequest {
   relationship: Relationship | null;
   targetId: UserId;

--- a/backend/test/game-gateway.e2e-spec.ts
+++ b/backend/test/game-gateway.e2e-spec.ts
@@ -161,14 +161,15 @@ describe('GameGateway (e2e)', () => {
 
   /*****************************************************************************
    *                                                                           *
-   * SECTION : newGame emitter                                                 *
+   * SECTION : newGame & newNormalGame emitter                                 *
    *                                                                           *
    ****************************************************************************/
   /**
-   * 게임이 매칭되었을 때, 초대 시 초대 받은 유저에게, 래더 시 두 유저에게 이벤트를 보낸다
+   * 게임이 매칭되었을 때, 초대 시 초대 받은 유저에게 newNormalGame 을
+   * 래더 시 두 유저에게 newGame 이벤트를 보낸다
    */
 
-  describe('newGame', () => {
+  describe('newGame & newNormalGame', () => {
     it('should notify both users when a new game is matched (ladder)', async () => {
       const [playerOne, playerTwo] = clientSockets;
       gateway.joinRoom(
@@ -195,8 +196,8 @@ describe('GameGateway (e2e)', () => {
         `game-${gameId}`,
       );
       const [wsMessageOne, wsError] = await Promise.allSettled([
-        listenPromise(playerOne, 'newGame'),
-        timeout(1000, listenPromise(playerTwo, 'newGame')),
+        listenPromise(playerOne, 'newNormalGame'),
+        timeout(1000, listenPromise(playerTwo, 'newNormalGame')),
         gateway.emitNewNormalGame(gameId, users[0].nickname),
       ]);
       if (wsMessageOne.status === 'rejected') {


### PR DESCRIPTION
## 개요
- #255 완료.

## 작업 사항
- 일반 게임 초대 요청을 받은 유저가 거절했을 때 서버에서 게임을 삭제하는 API 구현했습니다.

## 변경점
- 기존 게임 service 에 있던 예외 처리들을 Guards 들로 분리했습니다.

close #255
