### PR TITLE
:sparkles: feat : ErrorBoundary 및 Axios interceptor 를 활용한 Error handling 

### DIFF
--- a/backend/src/guard/mock-auth.guard.ts
+++ b/backend/src/guard/mock-auth.guard.ts
@@ -1,15 +1,22 @@
-import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 
 @Injectable()
 export class MockAuthGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const req = context.switchToHttp().getRequest();
-    if (req.user !== undefined) {
+    if (req.user !== undefined || process.env.NODE_ENV === 'production') {
       return true;
     }
     const userId = req.headers['x-user-id'];
     if (!userId || isNaN(userId)) {
-      return false;
+      throw new UnauthorizedException(
+        'x-user-id header is required in Dev mode',
+      );
     }
     req.user = { userId: Math.floor(Number(userId)) };
     return true;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Header from './components/common/Header';
 import Main from './components/common/Main';
 import Navigation from './components/common/Navigation';
 import UserIdInput from './UserIdInput.test';
+import ErrorBoundary from './components/common/ErrorBoundary';
 import './style/App.css';
 
 function App() {
@@ -13,11 +14,15 @@ function App() {
       {import.meta.env.DEV === true &&
         sessionStorage.getItem('x-user-id') === null && <UserIdInput />}
       <BrowserRouter>
-        <Header />
-        <Navigation />
-        <Suspense fallback={<div>Loading...</div>}>
-          <Main />
-        </Suspense>
+        <ErrorBoundary fallback={<header> 에러가 발생했어요~ </header>}>
+          <Header />
+        </ErrorBoundary>
+          <Navigation />
+        <ErrorBoundary fallback={<main> 에러가 발생했어요~ </main>}>
+          <Suspense fallback={<div>Loading...</div>}>
+            <Main />
+          </Suspense>
+        </ErrorBoundary>
       </BrowserRouter>
     </RecoilRoot>
   );

--- a/frontend/src/components/ChatRoom/Message.tsx
+++ b/frontend/src/components/ChatRoom/Message.tsx
@@ -33,7 +33,7 @@ function Message({ data }: Props) {
         src={
           user.isDefaultImage
             ? '/assets/defaultProfile.svg'
-            `/assets/profile-image/${props.userId}` 
+            : `/assets/profile-image/${data.senderId}`
         }
       />
 

--- a/frontend/src/components/Rank/MyRank.tsx
+++ b/frontend/src/components/Rank/MyRank.tsx
@@ -41,9 +41,10 @@ function MyRank({ myRankInfo, setMyRankInfo }: MyRankProps) {
         .then(({ data }) =>
           setUserData({
             nickname: data.nickname,
-            imageSrc: data.isDefaultImage === true
-              ? '/assets/defaultProfile.svg'
-              : `/assets/profile-image/${myId}`,
+            imageSrc:
+              data.isDefaultImage
+                ? '/assets/defaultProfile.svg'
+                : `/assets/profile-image/${myId}`,
           }),
         )
         .catch(() =>

--- a/frontend/src/components/Rank/RanksList.tsx
+++ b/frontend/src/components/Rank/RanksList.tsx
@@ -16,8 +16,6 @@ interface RanksListProps {
 
 function RanksList({ setMyRankInfo }: RanksListProps) {
   const myId = useRecoilValue(myIdState);
-  const activityMap = useRecoilValue(userActivity);
-  const relationshipMap = useRecoilValue(userRelationship);
   const [rankData, setRankData] = useState<Array<RankData>>([]);
   const [isEmpty, setIsEmpty] = useState(false);
 
@@ -27,7 +25,7 @@ function RanksList({ setMyRankInfo }: RanksListProps) {
       .get('/ranks?range=0,50')
       .then(({ data }) => setRankData(data.users))
       .catch(err => {
-        err.response.status === 404
+        err?.response?.status === 404
           ? setIsEmpty(true)
           : ErrorAlert(
               '랭킹을 불러오는데 실패했습니다.',

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,6 +1,4 @@
-import { AxiosError } from 'axios';
 import { Component, ErrorInfo, ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { ErrorAlert } from '../../util/Alert';
 
 interface Props {
@@ -22,17 +20,26 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidMount() {
-    window.onunhandledrejection = error => {
-      this.setState({ hasError: true });
-    };
+    window.addEventListener(
+      'unhandledrejection',
+      (error: PromiseRejectionEvent) => {
+        this.setState({ hasError: true });
+        error.preventDefault();
+      },
+    );
 
-    window.onerror = error => {
+    window.addEventListener('error', (error: ErrorEvent) => {
       this.setState({ hasError: true });
-    };
+      error.preventDefault();
+    });
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    ErrorAlert('오류가 발생하였습니다.', '잠시 후 다시 시도해주세요.');
+    ErrorAlert('오류가 발생하였습니다.', '잠시 후 다시 시도해주세요.').then(
+      () => {
+        this.setState({ hasError: false });
+      },
+    );
   }
 
   render() {

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import { AxiosError } from 'axios';
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ErrorAlert } from '../../util/Alert';
+
+interface Props {
+  fallback?: ReactNode;
+  children?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true };
+  }
+
+  componentDidMount() {
+    window.onunhandledrejection = error => {
+      this.setState({ hasError: true });
+    };
+
+    window.onerror = error => {
+      this.setState({ hasError: true });
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    ErrorAlert('오류가 발생하였습니다.', '잠시 후 다시 시도해주세요.');
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/frontend/src/components/hooks/CurrentUi.tsx
+++ b/frontend/src/components/hooks/CurrentUi.tsx
@@ -1,4 +1,4 @@
-import { ConfirmAlert } from '../../util/Alert';
+import { ConfirmAlert, ErrorAlert } from '../../util/Alert';
 import { listenOnce, socket } from '../../util/Socket';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -33,9 +33,13 @@ export function useCurrentUi(
 
   useEffect(() => {
     socket.once('connect_error', (error: WebSocketConnectError) => {
+      socket.off();
       socket.close();
       if (error.description === 403) {
+        ErrorAlert('로그인이 필요합니다.', '로그인 페이지로 이동합니다.');
         nav('/login');
+      } else {
+        ErrorAlert('서버와 연결할 수 없습니다.', '잠시 후 다시 시도해주세요.');
       }
     });
   }, [socket.connected]);
@@ -48,7 +52,7 @@ export function useCurrentUi(
       }
     } else {
       listenOnce('connect').then(() => {
-        socket.emit('currentUi', { ui }, ()=> setIsConnected(true));
+        socket.emit('currentUi', { ui }, () => setIsConnected(true));
       });
     }
     return () => {

--- a/frontend/src/style/Ranks.css
+++ b/frontend/src/style/Ranks.css
@@ -106,6 +106,7 @@
   box-shadow: 3px 3px 2px rgba(0, 0, 0, 0.25);
   cursor: pointer;
   margin: 0.625rem 1rem;
+  min-height: 5rem;
   text-decoration: none;
   transition: 0.8s;
   width: calc(100% - 2rem);

--- a/frontend/src/util/Axios.ts
+++ b/frontend/src/util/Axios.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { ErrorAlert } from './Alert';
 
 const instance =
   import.meta.env.DEV === true
@@ -8,6 +9,20 @@ const instance =
     : axios.create({
         baseURL: '/api',
       });
+
+instance.interceptors.response.use(
+  response => {
+    return response;
+  },
+  async error => {
+    if (error?.response?.status === 401) {
+      await ErrorAlert('로그인이 필요합니다.', '로그인 페이지로 이동합니다.');
+      window.location.href = '/login';
+      return new Promise(() => {});
+    }
+    return Promise.reject(error);
+  },
+);
 
 // FIXME : x-user-id 보내기
 instance.defaults.headers.common['x-user-id'] =

--- a/frontend/src/util/Recoils.ts
+++ b/frontend/src/util/Recoils.ts
@@ -11,14 +11,8 @@ export const myIdState = atom<number>({
   default: selector({
     key: 'myId/Default',
     get: async () => {
-      try {
-        const data = await instance.get('/user/id');
-        return data.data.userId;
-      } catch (e) {
-        ErrorAlert('로그인이 필요합니다.', '로그인 페이지로 이동합니다.').then(
-          () => (window.location.href = '/login'),
-        );
-      }
+      const data = await instance.get('/user/id');
+      return data.data.userId;
     },
   }),
 });

--- a/frontend/src/util/Recoils.ts
+++ b/frontend/src/util/Recoils.ts
@@ -4,7 +4,6 @@ import {
 } from '../components/hooks/SocketOnHooks';
 import { atom, atomFamily, selector } from 'recoil';
 import instance from './Axios';
-import { ErrorAlert } from './Alert';
 
 export const myIdState = atom<number>({
   key: 'myIdState',

--- a/frontend/src/views/Ranks.tsx
+++ b/frontend/src/views/Ranks.tsx
@@ -24,9 +24,11 @@ function Ranks() {
           </div>
         }
       >
-        <MyRank myRankInfo={myRankInfo} setMyRankInfo={setMyRankInfo} />
+        {isConnected && (
+          <MyRank myRankInfo={myRankInfo} setMyRankInfo={setMyRankInfo} />
+        )}
       </Suspense>
-      <RanksList setMyRankInfo={setMyRankInfo} />
+      {isConnected && <RanksList setMyRankInfo={setMyRankInfo} />}
     </div>
   );
 }


### PR DESCRIPTION
## 개요
- #265 완료
- #270 완료
- MockAuthGuard  수정
## 작업 사항
- MockAuthGuard 에서 에러시 401 리턴 및 development 환경에서만 작동하도록 변경
- ErrorBoundary 구현
  - [React 공식 문서](https://reactjs.org/docs/error-boundaries.html#introducing-error-boundaries) 및 [ErrorBoundary Typescript reference](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/error_boundaries/) 를 보고 만들었습니다.
  - Suspense 와 통일성을 위하여 fallback 를 Props 로 받아서, 에러시 fallback 를 렌더링 합니다.
  - 브라우저 전체에 [unhandledrejection_event](https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event) 및 [error_event](https://developer.mozilla.org/en-US/docs/Web/API/Window/error_event) 를 핸들링 하여 unhandled exception 을 막았습니다.

- axios interceptor 를 활용하여 401 응답 핸들링
  - 모든 응답에 대하여 401 응답이 오면 /login 으로 redirection 됩니다.
- Socket 에러와 401 에러는 /login 페이지가 구현되어야 더 확실해질 것 같습니다.
## 변경점
- MockAuthGuard 에서 인증 실패시 403 을 리턴했었는데, 원활한 테스트를 위하여 401 로 바꿨습니다.
