### PR TITLE
✨ feat : 채팅방에서 차단된 관계에 있는 유저의 메시지 제외 후 전송

### DIFF
--- a/backend/src/chats/chats.controller.ts
+++ b/backend/src/chats/chats.controller.ts
@@ -129,11 +129,17 @@ export class ChatsController {
   @Get(':channelId/message')
   @UseGuards(ChannelExistGuard, MemberExistGuard)
   findChannelMessages(
+    @Req() req: VerifiedRequest,
     @Param('channelId', ParseIntPipe) channelId: ChannelId,
     @Query('range', new ValidateRangePipe(RANGE_LIMIT_MAX))
     range: [offset: number, limit: number],
   ) {
-    return this.chatsService.findChannelMessages(channelId, range[0], range[1]);
+    return this.chatsService.findChannelMessages(
+      channelId,
+      req.user.userId,
+      range[0],
+      range[1],
+    );
   }
 
   @Post(':channelId/message')

--- a/backend/src/profile/profile.service.ts
+++ b/backend/src/profile/profile.service.ts
@@ -136,14 +136,15 @@ export class ProfileService {
         ).authEmail,
       };
     } catch (e) {
+      if (e instanceof EntityNotFoundError) {
+        throw new NotFoundException(
+          `Two-factor Authentication of a user(${userId}) is not enabled`,
+        );
+      }
       this.logger.error(e);
-      throw e instanceof EntityNotFoundError
-        ? new NotFoundException(
-            `Two-factor Authentication of a user(${userId}) is not enabled`,
-          )
-        : new InternalServerErrorException(
-            `Failed to find Two-factor email of a user (${userId})`,
-          );
+      throw new InternalServerErrorException(
+        `Failed to find Two-factor email of a user (${userId})`,
+      );
     }
   }
 

--- a/backend/src/user-status/activity.gateway.ts
+++ b/backend/src/user-status/activity.gateway.ts
@@ -80,10 +80,8 @@ export class ActivityGateway
     const socketId = clientSocket.id;
     this.userSocketStorage.clients.set(userId, socketId);
     this.userSocketStorage.sockets.set(socketId, userId);
-    await Promise.all([
-      this.userRelationshipStorage.load(userId),
-      this.channelStorage.loadUser(userId),
-    ]);
+    await this.userRelationshipStorage.load(userId);
+    await this.channelStorage.loadUser(userId);
     const joinedChannels = this.channelStorage.getUser(userId)?.keys();
     if (joinedChannels !== undefined) {
       for (const channelId of joinedChannels) {


### PR DESCRIPTION
## 개요
- #310 완료
## 작업 사항
- 차단된 관계의 유저 메시지를 더이상 보내주지 않습니다.
- `GET /chats/:channelId/message` 에서 차단된 유저의 메시지는 제외하고 응답합니다.
- "newMesssage" 이벤트에서 차단된 유저의 메시지는 emit 하지 않습니다.
- "messageArrive" 이벤트에서 차단된 유저의 메시지는 emit 하지 않습니다.
- 차단된 유저의 메시지가 도착할 경우 unseenCount 를 업데이트 하지 않습니다.
- channelStorage 에서 user 를 load 시 차단된 유저의 메시지는 unseenCount 에 카운트 하지 않습니다.

close #310