### PR TITLE
✨ feat : 차단 및 차단 해제 시 채팅방 메시지 실시간 업데이트 구현

### DIFF
--- a/backend/src/chats/chats.controller.ts
+++ b/backend/src/chats/chats.controller.ts
@@ -129,17 +129,11 @@ export class ChatsController {
   @Get(':channelId/message')
   @UseGuards(ChannelExistGuard, MemberExistGuard)
   findChannelMessages(
-    @Req() req: VerifiedRequest,
     @Param('channelId', ParseIntPipe) channelId: ChannelId,
     @Query('range', new ValidateRangePipe(RANGE_LIMIT_MAX))
     range: [offset: number, limit: number],
   ) {
-    return this.chatsService.findChannelMessages(
-      channelId,
-      req.user.userId,
-      range[0],
-      range[1],
-    );
+    return this.chatsService.findChannelMessages(channelId, range[0], range[1]);
   }
 
   @Post(':channelId/message')

--- a/backend/src/chats/chats.gateway.ts
+++ b/backend/src/chats/chats.gateway.ts
@@ -5,7 +5,6 @@ import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { WEBSOCKET_CONFIG } from '../config/constant/constant-config';
 import { ChannelId, SocketId, UserId, UserRole } from '../util/type';
 import { NewMessage } from './dto/chats-gateway.dto';
-import { UserRelationshipStorage } from '../user-status/user-relationship.storage';
 import { UserSocketStorage } from '../user-status/user-socket.storage';
 
 @WebSocketGateway(WEBSOCKET_CONFIG)
@@ -13,10 +12,7 @@ export class ChatsGateway {
   @WebSocketServer()
   private server: Server;
 
-  constructor(
-    private userSocketStorage: UserSocketStorage,
-    private readonly userRelationshipStorage: UserRelationshipStorage,
-  ) {}
+  constructor(private userSocketStorage: UserSocketStorage) {}
 
   /*****************************************************************************
    *                                                                           *
@@ -208,30 +204,14 @@ export class ChatsGateway {
   emitNewMessage(
     channelId: ChannelId,
     { senderId, messageId, contents, createdAt }: NewMessage,
-    blockedUsers: UserId[],
   ) {
-    const blockedUserSockets = [];
-    for (const blockedUser of blockedUsers) {
-      const relationship = this.userRelationshipStorage.getRelationship(
-        senderId,
-        blockedUser,
-      );
-      if (relationship === 'blocked' || relationship === 'blocker') {
-        blockedUserSockets.push(
-          this.userSocketStorage.clients.get(blockedUser),
-        );
-      }
-    }
-    this.server
-      .in(`chatRooms-${channelId}-active`)
-      .except(blockedUserSockets)
-      .emit('newMessage', {
-        senderId,
-        messageId,
-        contents,
-        createdAt: createdAt.toMillis(),
-      });
-    this.emitMessageArrived(channelId, blockedUserSockets);
+    this.server.in(`chatRooms-${channelId}-active`).emit('newMessage', {
+      senderId,
+      messageId,
+      contents,
+      createdAt: createdAt.toMillis(),
+    });
+    this.emitMessageArrived(channelId);
   }
 
   /**
@@ -350,14 +330,10 @@ export class ChatsGateway {
    *
    * @param channelId 채팅방의 id
    */
-  private emitMessageArrived(
-    channelId: ChannelId,
-    blockedUserSockets: SocketId[],
-  ) {
+  private emitMessageArrived(channelId: ChannelId) {
     this.server
       .in(`chatRooms-${channelId}`)
       .except(`chatRooms-${channelId}-active`)
-      .except(blockedUserSockets)
       .emit('messageArrived', { channelId });
   }
 

--- a/backend/src/chats/chats.gateway.ts
+++ b/backend/src/chats/chats.gateway.ts
@@ -119,7 +119,7 @@ export class ChatsGateway {
     this.joinChannelRoom(channelId, ownerId);
     this.joinChannelRoom(channelId, peerId);
     const socketId = this.userSocketStorage.clients.get(peerId);
-    if (this.getRoomMembers('chats').has(socketId)) {
+    if (this.getRoomMembers('chats')?.has(socketId)) {
       this.server.in(socketId).emit('channelCreated', {
         channelId,
         channelName,

--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -18,7 +18,6 @@ import {
   UpdateChannelDto,
 } from './dto/chats.dto';
 import { ChannelId, UserChannelStatus, UserId, UserRole } from '../util/type';
-import { ChannelMembers } from '../entity/channel-members.entity';
 import { ChannelStorage } from '../user-status/channel.storage';
 import { ChatsGateway } from './chats.gateway';
 import { Messages } from '../entity/messages.entity';
@@ -31,8 +30,6 @@ export class ChatsService {
   constructor(
     private readonly activityManager: ActivityManager,
     private readonly channelStorage: ChannelStorage,
-    @InjectRepository(ChannelMembers)
-    private readonly channelMembersRepository: Repository<ChannelMembers>,
     @InjectRepository(Channels)
     private readonly channelsRepository: Repository<Channels>,
     private readonly chatsGateway: ChatsGateway,

--- a/backend/src/chats/guard/member-messaging.guard.ts
+++ b/backend/src/chats/guard/member-messaging.guard.ts
@@ -3,6 +3,7 @@ import {
   ExecutionContext,
   ForbiddenException,
   Injectable,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { DateTime } from 'luxon';
 
@@ -28,7 +29,10 @@ export class MemberMessagingGuard implements CanActivate {
   checkIsReadonly(channelId: ChannelId, userId: UserId) {
     const muteEndAt = this.channelStorage
       .getUser(userId)
-      .get(channelId).muteEndAt;
+      ?.get(channelId).muteEndAt;
+    if (muteEndAt === undefined) {
+      throw new InternalServerErrorException('Cannot get muteEndAt');
+    }
     if (muteEndAt !== 'epoch' && muteEndAt > DateTime.now()) {
       const remains = Math.round(
         muteEndAt.diffNow().shiftTo('minutes').minutes,

--- a/backend/src/user/user.module.ts
+++ b/backend/src/user/user.module.ts
@@ -1,7 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
-import { ChatsModule } from 'src/chats/chats.module';
+import { ChatsModule } from '../chats/chats.module';
 import { GameModule } from '../game/game.module';
 import { UserController } from './user.controller';
 import { UserGateway } from './user.gateway';

--- a/frontend/src/components/ChatRoom/ChatList.tsx
+++ b/frontend/src/components/ChatRoom/ChatList.tsx
@@ -1,9 +1,13 @@
-import { useEffect, useRef, useState } from 'react';
+import { lazy, useEffect, useRef, useState } from 'react';
 import { socket } from '../../util/Socket';
 import instance from '../../util/Axios';
-import Message from './Message';
+import { useRecoilValue } from 'recoil';
+import { userRelationship } from '../../util/Recoils';
+import { relationshipData } from '../hooks/SocketOnHooks';
 
 const BUTTON_IMG_PATH = '/assets/arrow-up-circle.png';
+
+const Message = lazy(() => import('./Message'));
 
 interface Props {
   id: string;
@@ -16,6 +20,17 @@ interface MessageData {
   senderId: number;
 }
 
+function isBlockedMessage(
+  senderId: number,
+  relationshipMap: Map<number, relationshipData>,
+) {
+  const relationship = relationshipMap.get(senderId)?.relationship;
+  if (relationship === 'blocker' || relationship === 'blocked') {
+    return true;
+  }
+  return false;
+}
+
 function ChatList(props: Props) {
   const [contents, setContents] = useState<MessageData[]>([]);
   const chatListDivRef = useRef<HTMLDivElement>(null);
@@ -23,6 +38,7 @@ function ChatList(props: Props) {
   const [isMoreMessage, setIsMoreMessage] = useState<boolean>(true);
   const [isClick, setIsClick] = useState<boolean>(false);
   const [currentHeight, setCurrentHeight] = useState<number>(0);
+  const relationshipMap = useRecoilValue(userRelationship);
 
   const dataFetch = () => {
     instance
@@ -48,6 +64,7 @@ function ChatList(props: Props) {
     dataFetch();
     setIsClick(true);
   };
+
   useEffect(() => {
     instance
       .get(`/chats/${props.id}/message?range=0,100`)
@@ -94,9 +111,12 @@ function ChatList(props: Props) {
           <img className="upButtonImage" src={BUTTON_IMG_PATH}></img>
         </button>
       )}
-      {contents.map(data => (
-        <Message key={data.messageId} data={data} />
-      ))}
+      {contents.map(
+        data =>
+          isBlockedMessage(data.senderId, relationshipMap) || (
+            <Message key={data.messageId} data={data} />
+          ),
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ChatRoom/ChatList.tsx
+++ b/frontend/src/components/ChatRoom/ChatList.tsx
@@ -102,6 +102,9 @@ function ChatList(props: Props) {
       const { scrollHeight, clientHeight } = chatListDivRef.current;
       chatListDivRef.current.scrollTop = scrollHeight - clientHeight;
     }
+    return () => {
+      setIsClick(false);
+    };
   }, [contents]);
 
   return (

--- a/frontend/src/components/Chats/PasswordForm.tsx
+++ b/frontend/src/components/Chats/PasswordForm.tsx
@@ -51,11 +51,11 @@ function PasswordForm({ hideModal, myId, channelId }: PasswordFormProps) {
   return (
     <>
       <form className="formModalBody" onSubmit={handleSubmit} id="joinChat">
-          <ChannelPasswordField
-            password={password}
-            error={error}
-            handlePassword={handlePassword}
-          />
+        <ChannelPasswordField
+          password={password}
+          error={error}
+          handlePassword={handlePassword}
+        />
       </form>
       <div className="formModalButtons">
         <button

--- a/frontend/src/components/Chats/interface.ts
+++ b/frontend/src/components/Chats/interface.ts
@@ -2,7 +2,7 @@ export interface ChannelInfo {
   channelId: number;
   channelName: string;
   memberCount: number;
-  accessMode: "public" | "protected" | "private";
+  accessMode: 'public' | 'protected' | 'private';
   isDm?: boolean;
   unseenCount?: number;
 }

--- a/frontend/src/components/Rank/MyRank.tsx
+++ b/frontend/src/components/Rank/MyRank.tsx
@@ -41,10 +41,9 @@ function MyRank({ myRankInfo, setMyRankInfo }: MyRankProps) {
         .then(({ data }) =>
           setUserData({
             nickname: data.nickname,
-            imageSrc:
-              data.isDefaultImage
-                ? '/assets/defaultProfile.svg'
-                : `/assets/profile-image/${myId}`,
+            imageSrc: data.isDefaultImage
+              ? '/assets/defaultProfile.svg'
+              : `/assets/profile-image/${myId}`,
           }),
         )
         .catch(() =>

--- a/frontend/src/components/Search/SearchModalFooter.tsx
+++ b/frontend/src/components/Search/SearchModalFooter.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo } from 'react';
 
 interface SearchModalFooterProps {
   actionName: string;

--- a/frontend/src/components/Search/hooks/SearchKeyPress.tsx
+++ b/frontend/src/components/Search/hooks/SearchKeyPress.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
 export const useKeyPress = (targetKey: string) => {
   const [keyPressed, setKeyPressed] = useState<boolean>(false);

--- a/frontend/src/components/hooks/CurrentUi.tsx
+++ b/frontend/src/components/hooks/CurrentUi.tsx
@@ -2,7 +2,7 @@ import { ConfirmAlert, ErrorAlert } from '../../util/Alert';
 import instance from '../../util/Axios';
 import { listenOnce, socket } from '../../util/Socket';
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 interface WebSocketConnectError extends Error {
   description?: number;
@@ -45,6 +45,17 @@ export function useCurrentUi(
       }
     });
   }, [socket.connected]);
+
+  useEffect(() => {
+    socket.on('disconnect', () => {
+      setTimeout(() => {
+        socket.connect();
+      }, 2000);
+    });
+    return () => {
+      socket.off('disconnect');
+    };
+  }, []);
 
   useEffect(() => {
     if (isConnected) {

--- a/frontend/src/views/ChatRoom.tsx
+++ b/frontend/src/views/ChatRoom.tsx
@@ -22,14 +22,18 @@ function ChatRoom() {
     return () => {};
   }, [id]);
 
-  return (
+  return isConnected ? (
     <div className="chatRoom">
-      <div>{isConnected && <UserList id={id ?? ''} />}</div>
+      <div>
+        <UserList id={id ?? ''} />
+      </div>
       <div className="chatRoomRight">
         <ChatList id={id ?? ''} />
         <ChatInput id={id ?? ''} />
       </div>
     </div>
+  ) : (
+    <></>
   );
 }
 


### PR DESCRIPTION
## 개요
- #329 구현

## 작업 사항
- 차단 및 차단 해제시 메시지 숨김 / 리렌더링
  - #312 PR 로 서버 에서 차단된 유저의 메시지를 제외하고 응답을 보내줬는데, 차단 해제시 메시지를 다시 보여주기 위하여 롤백

## 변경점
- message 를 렌더링 하기 위하여 recoil 을 쓰기 때문에 해당 컴포넌트를 lazy 로 바꿔줬습니다.
- chatRooms 에서 socket 에 connect 되었을 때만 하위 컴포넌트가 렌더링 되도록 바꿨습니다.

## 남은 이슈
- 차단된 유저의 메시지만 제외하고 보여주게 되면서, 더 보기 버튼이 메시지 100개 이하일때 활성화 됨

close #329 