### PR TITLE
🐛 fix : 소켓 disconnect 후 cache 가 필요한 요청 오면 500 에러

### DIFF
--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -62,6 +62,12 @@ export class ChatsService {
       return { joinedChannels: [], otherChannels: [] };
     }
     const userChannelMap = this.channelStorage.getUser(userId);
+    if (
+      userChannelMap === undefined ||
+      this.channelStorage.getChannels() === undefined
+    ) {
+      throw new InternalServerErrorException('Cannot get userChannelMap');
+    }
     return {
       joinedChannels: await this.getJoinedChannels(userId, userChannelMap),
       otherChannels: await this.getChannelsExceptJoined(userId, userChannelMap),

--- a/backend/src/chats/chats.service.ts
+++ b/backend/src/chats/chats.service.ts
@@ -66,7 +66,7 @@ export class ChatsService {
       userChannelMap === undefined ||
       this.channelStorage.getChannels() === undefined
     ) {
-      throw new InternalServerErrorException('Cannot get userChannelMap');
+      throw new InternalServerErrorException('Failed to load channels');
     }
     return {
       joinedChannels: await this.getJoinedChannels(userId, userChannelMap),

--- a/backend/src/user-status/channel.storage.ts
+++ b/backend/src/user-status/channel.storage.ts
@@ -576,12 +576,6 @@ export class ChannelStorage implements OnModuleInit {
     }
   }
 
-  /*****************************************************************************
-   *                                                                           *
-   * NOTE : TEST ONLY                                                          *
-   *                                                                           *
-   ****************************************************************************/
-
   getChannels() {
     return this.channels;
   }

--- a/backend/src/user-status/user-relationship.storage.ts
+++ b/backend/src/user-status/user-relationship.storage.ts
@@ -241,7 +241,13 @@ export class UserRelationshipStorage implements OnModuleInit {
     const friends: UserId[] = [];
     const pendingSenders: UserId[] = [];
     const pendingReceivers: UserId[] = [];
-    this.users.get(userId).forEach((status, counterpartId) => {
+    const relationship = this.users.get(userId);
+    if (relationship === undefined) {
+      throw new InternalServerErrorException(
+        'Failed to load user relationships',
+      );
+    }
+    relationship.forEach((status, counterpartId) => {
       switch (status) {
         case 'friend':
           friends.push(counterpartId);


### PR DESCRIPTION
## 개요
- 소켓 disconnect 후 cache 가 필요한 요청이 오면 load 가 안되어 있기 때문에 500 에러를 던져줍니다.
