### PR TITLE
:bug: fix : search modal 에서 default profile 깨지는 문제 해결

### DIFF
--- a/frontend/src/components/Search/SearchModalBody.tsx
+++ b/frontend/src/components/Search/SearchModalBody.tsx
@@ -51,7 +51,7 @@ function SearchModalBody({ searchResult, searchAction }: SearchModalBodyProps) {
             <img
               src={
                 user.isDefaultImage
-                  ? '/assets/defaultProfile'
+                  ? '/assets/defaultProfile.svg'
                   : `/assets/profile-image/${user.userId}`
               }
               className="searchResultImage selectNone"


### PR DESCRIPTION
## 개요
- search modal 에서 defaultProfile 에 확장자를 안붙여서 이미지가 깨지던 문제 해결